### PR TITLE
Handle meta key (⌘  on OS X)

### DIFF
--- a/modules/keypress/keypress.js
+++ b/modules/keypress/keypress.js
@@ -46,7 +46,8 @@ factory('keypressHelper', ['$parse', function keypress($parse){
     // Check only matching of pressed keys one of the conditions
     elm.bind(mode, function (event) {
       // No need to do that inside the cycle
-      var altPressed = !!(event.metaKey || event.altKey);
+      var metaPressed = !!(event.metaKey && !event.ctrlKey);
+      var altPressed = !!event.altKey;
       var ctrlPressed = !!event.ctrlKey;
       var shiftPressed = !!event.shiftKey;
       var keyCode = event.keyCode;
@@ -61,12 +62,14 @@ factory('keypressHelper', ['$parse', function keypress($parse){
 
         var mainKeyPressed = combination.keys[keysByCode[event.keyCode]] || combination.keys[event.keyCode.toString()];
 
+        var metaRequired = !!combination.keys.meta;
         var altRequired = !!combination.keys.alt;
         var ctrlRequired = !!combination.keys.ctrl;
         var shiftRequired = !!combination.keys.shift;
 
         if (
           mainKeyPressed &&
+          ( metaRequired == metaPressed ) &&
           ( altRequired == altPressed ) &&
           ( ctrlRequired == ctrlPressed ) &&
           ( shiftRequired == shiftPressed )

--- a/modules/keypress/test/keydownSpec.js
+++ b/modules/keypress/test/keydownSpec.js
@@ -2,13 +2,14 @@ describe('uiKeydown', function () {
 
   var $scope, $compile;
 
-  var createKeyEvent = function (mainKey, alt, ctrl, shift) {
+  var createKeyEvent = function (mainKey, alt, ctrl, shift, meta) {
     var keyEvent = jQuery.Event("keydown");
 
     keyEvent.keyCode = mainKey;
     keyEvent.altKey = alt;
     keyEvent.ctrlKey = ctrl;
     keyEvent.shiftKey = shift;
+    keyEvent.metaKey = meta;
 
     return keyEvent;
   };
@@ -34,13 +35,13 @@ describe('uiKeydown', function () {
   });
 
   it('should support combined key press', function () {
-    createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true));
+    createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event).toBe(true);
   });
   
   it('should support alternative combinations', function () {
     $scope.event = 0;
-    createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true)).trigger(createKeyEvent(14, false, true, true));
+    createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true, false)).trigger(createKeyEvent(14, false, true, true, false));
     expect($scope.event).toBe(2);
   });
 
@@ -50,8 +51,15 @@ describe('uiKeydown', function () {
     elm.trigger(createKeyEvent(13));
     expect($scope.event1).toBe(true);
 
-    elm.trigger(createKeyEvent(13, false, true, true));
+    elm.trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event2).toBe(true);
+  });
+
+  it('should handle meta key ("⌘" on OS X)', function () {
+    var elm = createElement({'meta-83': 'event1=true'});
+
+    elm.trigger(createKeyEvent(83, false, false, false, true));
+    expect($scope.event1).toBe(true);
   });
 
   it('should support $event in expressions', function () {

--- a/modules/keypress/test/keypressSpec.js
+++ b/modules/keypress/test/keypressSpec.js
@@ -3,13 +3,14 @@ describe('uiKeypress', function () {
 
   var $scope, $compile;
 
-  var createKeyEvent = function (mainKey, alt, ctrl, shift) {
+  var createKeyEvent = function (mainKey, alt, ctrl, shift, meta) {
     var keyEvent = jQuery.Event("keypress");
 
     keyEvent.keyCode = mainKey;
     keyEvent.altKey = alt;
     keyEvent.ctrlKey = ctrl;
     keyEvent.shiftKey = shift;
+    keyEvent.metaKey = meta;
 
     return keyEvent;
   };
@@ -35,13 +36,13 @@ describe('uiKeypress', function () {
   });
 
   it('should support combined key press', function () {
-    createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true));
+    createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event).toBe(true);
   });
   
   it('should support alternative combinations', function () {
     $scope.event = 0;
-    createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true)).trigger(createKeyEvent(14, false, true, true));
+    createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true, false)).trigger(createKeyEvent(14, false, true, true, false));
     expect($scope.event).toBe(2);
   });
 
@@ -51,8 +52,15 @@ describe('uiKeypress', function () {
     elm.trigger(createKeyEvent(13));
     expect($scope.event1).toBe(true);
 
-    elm.trigger(createKeyEvent(13, false, true, true));
+    elm.trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event2).toBe(true);
+  });
+
+  it('should handle meta key ("⌘" on OS X)', function () {
+    var elm = createElement({'meta-83': 'event1=true'});
+
+    elm.trigger(createKeyEvent(83, false, false, false, true));
+    expect($scope.event1).toBe(true);
   });
 
   it('should support $event in expressions', function () {

--- a/modules/keypress/test/keyupSpec.js
+++ b/modules/keypress/test/keyupSpec.js
@@ -2,13 +2,14 @@ describe('uiKeyup', function () {
 
   var $scope, $compile;
 
-  var createKeyEvent = function (mainKey, alt, ctrl, shift) {
+  var createKeyEvent = function (mainKey, alt, ctrl, shift, meta) {
     var keyEvent = jQuery.Event("keyup");
 
     keyEvent.keyCode = mainKey;
     keyEvent.altKey = alt;
     keyEvent.ctrlKey = ctrl;
     keyEvent.shiftKey = shift;
+    keyEvent.metaKey = meta;
 
     return keyEvent;
   };
@@ -34,13 +35,13 @@ describe('uiKeyup', function () {
   });
 
   it('should support combined key press', function () {
-    createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true));
+    createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event).toBe(true);
   });
   
   it('should support alternative combinations', function () {
     $scope.event = 0;
-    createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true)).trigger(createKeyEvent(14, false, true, true));
+    createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true, false)).trigger(createKeyEvent(14, false, true, true, false));
     expect($scope.event).toBe(2);
   });
 
@@ -50,8 +51,15 @@ describe('uiKeyup', function () {
     elm.trigger(createKeyEvent(13));
     expect($scope.event1).toBe(true);
 
-    elm.trigger(createKeyEvent(13, false, true, true));
+    elm.trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event2).toBe(true);
+  });
+
+  it('should handle meta key ("⌘" on OS X)', function () {
+    var elm = createElement({'meta-83': 'event1=true'});
+
+    elm.trigger(createKeyEvent(83, false, false, false, true));
+    expect($scope.event1).toBe(true);
   });
 
   it('should support $event in expressions', function () {


### PR DESCRIPTION
Adding support for meta key (⌘ on OS X) in the keypress directive.
