### PR TITLE
Support for optional-part to a mask

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -15,6 +15,8 @@ angular.module('ui.mask',[]).directive('uiMask', [
       link: function (scope, iElement, iAttrs, controller) {
         var maskProcessed = false, eventsBound = false,
             maskCaretMap, maskPatterns, maskPlaceholder, maskComponents,
+            // Minimum required length of the value to be considered valid
+            minRequiredLength,
             value, valueMasked, isValid,
             // Vars for initializing/uninitializing
             originalPlaceholder = iAttrs.placeholder,
@@ -130,7 +132,7 @@ angular.module('ui.mask',[]).directive('uiMask', [
 
         function validateValue(value) {
           // Zero-length value validity is ngRequired's determination
-          return value.length ? value.length === maskCaretMap.length - 1 : true;
+          return value.length ? value.length >= minRequiredLength : true;
         }
 
         function unmaskValue(value) {
@@ -191,16 +193,27 @@ angular.module('ui.mask',[]).directive('uiMask', [
           // else
 
           if (typeof mask === 'string') {
+            minRequiredLength = 0;
+            var isOptional = false;
+
             angular.forEach(mask.split(''), function(chr, i) {
               if (maskDefinitions[chr]) {
                 maskCaretMap.push(characterCount);
                 maskPlaceholder += '_';
                 maskPatterns.push(maskDefinitions[chr]);
+
+                characterCount++;
+                if (!isOptional) {
+                  minRequiredLength++;
+                }
+              }
+              else if (chr === "?") {
+                isOptional = true;
               }
               else{
                 maskPlaceholder += chr;
+                characterCount++;
               }
-              characterCount++;
             });
           }
           // Caret position immediately following last position is valid.


### PR DESCRIPTION
I needed the ability to have an optional part of the mask: phone numbers that are 10 **or** 11 characters long (see below).

This pull-request achieves this by supporting **one** _optional section_ to a mask, delineated by the `?` character.  This is the same format used by the popular [jQuery masked input plugin](http://digitalbush.com/projects/masked-input-plugin/).

For example:

```
   <input ui-mask="019999999999?9" />
```

will accept German mobile numbers with 10 or 11 user-input digits.
