### PR TITLE
Keypress Module: Take keyCode normalization into account when checking key combinations

### DIFF
--- a/modules/keypress/keypress.js
+++ b/modules/keypress/keypress.js
@@ -60,7 +60,7 @@ factory('keypressHelper', ['$parse', function keypress($parse){
       // Iterate over prepared combinations
       angular.forEach(combinations, function (combination) {
 
-        var mainKeyPressed = combination.keys[keysByCode[event.keyCode]] || combination.keys[event.keyCode.toString()];
+        var mainKeyPressed = combination.keys[keysByCode[keyCode]] || combination.keys[keyCode.toString()];
 
         var metaRequired = !!combination.keys.meta;
         var altRequired = !!combination.keys.alt;


### PR DESCRIPTION
I haven't encountered any problems and actuelly I don't know about the fact that keypress keycodes should be normalized. Anyway the normalized code should be used in the loop instead of the original keycode from the event object to have an effect.
