### PR TITLE
Custom placeholder chars using token expression.

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -42,6 +42,19 @@ angular.module('ui.mask', [])
             return true;
           }
 
+          function initPlaceholder(placeholderAttr) {
+            if(! angular.isDefined(placeholderAttr)) {
+              return;
+            }
+
+            maskPlaceholder = placeholderAttr;
+
+            // If the mask is processed, then we need to update the value
+            if (maskProcessed) {
+              eventHandler();
+            }
+          }
+
           function formatter(fromModelValue){
             if (!maskProcessed) {
               return fromModelValue;
@@ -94,6 +107,7 @@ angular.module('ui.mask', [])
           }
 
           iAttrs.$observe('uiMask', initialize);
+          iAttrs.$observe('placeholder', initPlaceholder);
           controller.$formatters.push(formatter);
           controller.$parsers.push(parser);
 

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -177,6 +177,27 @@ describe('uiMask', function () {
       expect(input.val()).toBe('12/DD/YYYY');
     });
 
+    it("should update mask substitutions via the placeholder attribute", function() {
+
+      var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' placeholder='{{placeholder}}'>",
+          input           = compileElement(placeholderHtml);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '99/99/9999'");
+      scope.$apply("placeholder = 'DD/MM/YYYY'");
+      expect(input.attr("placeholder")).toBe("DD/MM/YYYY");
+
+      input.val("12").triggerHandler("input");
+      expect(input.val()).toBe("12/MM/YYYY");
+
+      scope.$apply("placeholder = 'MM/DD/YYYY'");
+      expect(input.val()).toBe("12/DD/YYYY");
+
+      input.triggerHandler("blur");
+      expect(input.attr("placeholder")).toBe("MM/DD/YYYY");
+    });
+
+
   });
 
   describe('configuration', function () {


### PR DESCRIPTION
Allows you to quickly define a custom placeholder.

Example:

```
<input ui-mask = "99/99" placeholder="MM/YY">
```

Sets placeholder to "MM/YY" instead of "**/**"

This patch does not affect existing functionality.
