### PR TITLE
Fix to erronous type comparison in scrollfix module

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -13,12 +13,12 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
           $target = uiScrollfixTarget && uiScrollfixTarget.$element || angular.element($window);
       if (!attrs.uiScrollfix) {
         attrs.uiScrollfix = top;
-      } else {
+      } else if (typeof(attrs.uiScrollfix) === 'string') {
         // charAt is generally faster than indexOf: http://jsperf.com/indexof-vs-charat
-        if (attrs.uiScrollfix.toString().charAt(0) === '-') {
-          attrs.uiScrollfix = top - parseFloat(attrs.uiScrollfix.toString().substr(1));
-        } else if (attrs.uiScrollfix.toString().charAt(0) === '+') {
-          attrs.uiScrollfix = top + parseFloat(attrs.uiScrollfix.toString().substr(1));
+        if (attrs.uiScrollfix.charAt(0) === '-') {
+          attrs.uiScrollfix = top - parseFloat(attrs.uiScrollfix.substr(1));
+        } else if (attrs.uiScrollfix.charAt(0) === '+') {
+          attrs.uiScrollfix = top + parseFloat(attrs.uiScrollfix.substr(1));
         }
       }
 


### PR DESCRIPTION
On `Google Chrome 28.0.1500.68` the scrollfix module causes the following error:

```
TypeError: Object 165 has no method 'charAt'
    at link (http://localhost:8080/components/angular-ui-utils/modules/scrollfix/scrollfix.js:18:31)
    at nodeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4959:13)
    at compositeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4550:15)
    at compositeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4553:13)
    at compositeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4553:13)
    at nodeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4953:24)
    at compositeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4550:15)
    at nodeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4953:24)
    at http://localhost:8080/components/angular-unstable/angular.js:5099:15
    at nodeLinkFn (http://localhost:8080/components/angular-unstable/angular.js:4953:24) <p ui-scrollfix=""> angular.js:6349
```

`angular-unstable` is version `1.1.5` from [Johannes Troeger's repository](https://github.com/johannestroeger/bower-angular-unstable).

I added type detection to avoid running string operations on incompatible data types.
