### PR TITLE
Dependency typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the specific modules to your dependencies, or add the entire lib by dependin
 ```javascript
 angular.module('myApp', ['ui.keypress', 'ui.event', ...])
 // or if ALL modules are loaded along with modules/utils.js
-angular.module('myApp', ['ui.utils'])
+angular.module('myApp', ['ui'])
 ```
 
 Each directive and filter is now it's own module and will have a relevant README.md in their respective folders


### PR DESCRIPTION
The doc suggested using ui.utils as a dependecy to start using AngularUI but it does not work because the directive in the code is named ui. The AngularUI code was downloaded using Nuget in Visual Studio.
