### PR TITLE
Fix for Travis error

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+	"directory": "components"
+}


### PR DESCRIPTION
I noticed that Travis was erroring on trying to execute components/angular-ui-docs/.travis/before_script.sh - this is because Bower changed the default install location to `bower_components`.

This PR adds a .bowerrc file that lets you control the directory to install to so that `bower install` will install everything to the `components` directory, although changing this to `bower_components` and fixing the urls in the `angular-ui-docs` repo to this new install location should probably be done to match the change in Bower.
