### PR TITLE
Added uiInclude directive in module ui.include.

### DIFF
--- a/modules/include/include.js
+++ b/modules/include/include.js
@@ -1,0 +1,66 @@
+// modeled after: angular-1.0.7/src/ng/directive/ngInclude.js
+angular.module('ui.include',[])
+.directive('uiInclude', ['$http', '$templateCache', '$anchorScroll', '$compile',
+                 function($http,   $templateCache,   $anchorScroll,   $compile) {
+  return {
+    restrict: 'ECA',
+    terminal: true,
+    compile: function(element, attr) {
+      var srcExp = attr.uiInclude || attr.src,
+          fragExp = attr.fragment || '',
+          onloadExp = attr.onload || '',
+          autoScrollExp = attr.autoscroll;
+
+      return function(scope, element) {
+        var changeCounter = 0,
+            childScope;
+
+        var clearContent = function() {
+          if (childScope) {
+            childScope.$destroy();
+            childScope = null;
+          }
+
+          element.html('');
+        };
+
+        function ngIncludeWatchAction() {
+          var thisChangeId = ++changeCounter;
+          var src = scope.$eval(srcExp);
+          var fragment = scope.$eval(fragExp);
+
+          if (src) {
+            $http.get(src, {cache: $templateCache}).success(function(response) {
+              if (thisChangeId !== changeCounter) { return; }
+
+              if (childScope) { childScope.$destroy(); }
+              childScope = scope.$new();
+
+              var contents;
+              if (fragment) {
+                contents = angular.element('<div/>').html(response).find(fragment);
+              }
+              else {
+                contents = angular.element('<div/>').html(response).contents();
+              }
+              element.html(contents);
+              $compile(contents)(childScope);
+
+              if (angular.isDefined(autoScrollExp) && (!autoScrollExp || scope.$eval(autoScrollExp))) {
+                $anchorScroll();
+              }
+
+              childScope.$emit('$includeContentLoaded');
+              scope.$eval(onloadExp);
+            }).error(function() {
+              if (thisChangeId === changeCounter) { clearContent(); }
+            });
+          } else { clearContent(); }
+        }
+
+        scope.$watch(fragExp, ngIncludeWatchAction);
+        scope.$watch(srcExp, ngIncludeWatchAction);
+      };
+    }
+  };
+}]);

--- a/modules/include/test/includeSpec.js
+++ b/modules/include/test/includeSpec.js
@@ -1,0 +1,41 @@
+// modeled after: angular.js/test/ng/directive/ngIncludeSpec.js
+describe('uiInclude', function() {
+  var element;
+
+  afterEach(function() {
+    element.remove();
+  });
+
+  beforeEach(module('ui.include'));
+
+  function putIntoCache(url, content) {
+    return function($templateCache) {
+      $templateCache.put(url, [200, content, {}]);
+    };
+  }
+
+  it('should include on external file', inject(putIntoCache('myUrl', '{{name}}'),
+      function($rootScope, $compile) {
+    element = angular.element('<div ui-include src="url"></div>');
+    angular.element(document.body).append(element);
+    element = $compile(element)($rootScope);
+    $rootScope.name = 'misko';
+    $rootScope.url = 'myUrl';
+    $rootScope.$digest();
+    expect(element.text()).toEqual('misko');
+    angular.element(document.body).html('');
+  }));
+
+  it('should work with a fragment selector', inject(putIntoCache('myUrl', '<a>foo {{name}}</a><b>bar {{name}}</b><c>baz {{name}}</c>'),
+      function($rootScope, $compile) {
+    element = angular.element('<div ui-include="url" fragment="\'b\'"></div>');
+    angular.element(document.body).append(element);
+    element = $compile(element)($rootScope);
+    $rootScope.name = 'misko';
+    $rootScope.url = 'myUrl';
+    $rootScope.$digest();
+    expect(element.text()).toEqual('bar misko');
+    angular.element(document.body).html('');
+  }));
+
+});


### PR DESCRIPTION
Directive was proposed here: angular/angular.js#3151 and should resolve issue: angular/angular.js#946.

Usage:

``` html
<ui-include src="'my/url/to/partial/file'" fragment="'#id-to-fragment'"></ui-include>
```

The fragment and src attributes are Angular expressions. When fragment is specified, it uses angular.element().find(), and therefore requires jQuery if full selectors are desired, otherwise falls back to Angular's jqLite (which can only find by element name).
