### PR TITLE
Fix#94: input with mask is autofocused in IE10.

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -430,6 +430,7 @@ angular.module('ui.mask', [])
             if (input.setSelectionRange) {
               input.focus();
               input.setSelectionRange(pos, pos);
+              input.blur();
             }
             else if (input.createTextRange) {
               // Curse you IE


### PR DESCRIPTION
This tiny fix is for #94 issue.
