### PR TITLE
Added focus as a trigger event for mask

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "author": "AngularUI Team",
   "name": "angular-ui-utils",
   "description": "AngularUI Utilities - Companion Suite for AngularJS",
-  "version": "0.0.5",
+  "version": "0.0.4",
   "homepage": "http://angular-ui.github.com",
   "main": "./modules/utils.js",
   "dependencies": {


### PR DESCRIPTION
When using mask with an input field that uses ng-required, if form validation fails the mask field is automatically focused but mask's eventHandler isn't triggered, which causes the first character typed to be behind the caret:

```
^ = caret
Field: [        ]
on validation failure because of empty && required:
Field: [^       ]
after typing one character, "G":
Field: [^G      ]
after typing another character, "O":
Field: [O^G     ]
```

This seems to be an issue on webkit browsers supporting the required attribute.  Fixed by binding onfocus to the eventHandler as well.
