### PR TITLE
fixed bower.json to ignore files which individual project installs of this project do not need.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "author": "AngularUI Team",
-  "name": "infowrap-angular-ui-utils",
+  "name": "angular-ui-utils",
   "description": "AngularUI Utilities - Companion Suite for AngularJS",
   "version": "0.0.4",
   "homepage": "http://angular-ui.github.com",


### PR DESCRIPTION
When using "*_/_.js" global file includes of bower components, unneeded files will be included in a project.

Additionally, bower installs just don't need any of the ignored files specified here.
