### PR TITLE
Added focus as a trigger event for mask

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -153,7 +153,7 @@ angular.module('ui.mask', [])
             }
             iElement.bind('blur', blurHandler);
             iElement.bind('mousedown mouseup', mouseDownUpHandler);
-            iElement.bind('input keyup click', eventHandler);
+            iElement.bind('input keyup click focus', eventHandler);
             eventsBound = true;
           }
 
@@ -167,6 +167,7 @@ angular.module('ui.mask', [])
             iElement.unbind('input', eventHandler);
             iElement.unbind('keyup', eventHandler);
             iElement.unbind('click', eventHandler);
+            iElement.unbind('focus', eventHandler);
             eventsBound = false;
           }
 


### PR DESCRIPTION
When using mask with an input field that uses ng-required, if form validation fails the mask field is automatically focused but mask's eventHandler isn't triggered, which causes the first character typed to be behind the caret:

```
^ = caret
Field: [        ]
on validation failure because of empty && required:
Field: [^       ]
after typing one character, "G":
Field: [^G      ]
after typing another character, "O":
Field: [O^G     ]
```

This seems to be an issue on webkit browsers supporting the required attribute.  Fixed by binding onfocus to the eventHandler as well.
