### PR TITLE
Updated code for assigning of events

### DIFF
--- a/modules/event/event.js
+++ b/modules/event/event.js
@@ -5,24 +5,52 @@
  *
  * @example <input ui-event="{ focus : 'counter++', blur : 'someCallback()' }">
  * @example <input ui-event="{ myCustomEvent : 'myEventHandler($event, $params)'}">
+ * @example <input ui-event="objectWithEvents">  // Somewhere in code (controller, directive...):
+ *                                               // $scope.objectWithEvents = { myCustomEvent : 'myEventHandler($event, $params)'};
  *
  * @param ui-event {string|object literal} The event to bind to as a string or a hash of events with their callbacks
  */
 angular.module('ui.event',[]).directive('uiEvent', ['$parse',
   function ($parse) {
     return function ($scope, elm, attrs) {
+
+      function registerEvents(events) {
+        angular.forEach(events, function (uiEvent, eventName) {
+          var fn = $parse(uiEvent);
+          elm.bind(eventName, function (evt) {
+            var params = Array.prototype.slice.call(arguments);
+            //Take out first paramater (event object);
+            params = params.splice(1);
+            fn($scope, {$event: evt, $params: params});
+            if (!$scope.$$phase) {
+              $scope.$apply();
+            }
+          });
+        });
+      }
+
+      function unregisterEvents(events) {
+        angular.forEach(events, function (uiEvent, eventName) {
+          elm.unbind(eventName);
+        });
+      }
+
       var events = $scope.$eval(attrs.uiEvent);
-      angular.forEach(events, function (uiEvent, eventName) {
-        var fn = $parse(uiEvent);
-        elm.bind(eventName, function (evt) {
-          var params = Array.prototype.slice.call(arguments);
-          //Take out first paramater (event object);
-          params = params.splice(1);
-          fn($scope, {$event: evt, $params: params});
-          if (!$scope.$$phase) {
-            $scope.$apply();
+      var expr = new RegExp('^[^{]');
+      if (attrs.uiEvent && expr.test(attrs.uiEvent)) {
+        $scope.$watch(attrs.uiEvent, function(newEvents, oldEvents) {
+          if (oldEvents) {
+            unregisterEvents(oldEvents);
+          }
+          if (newEvents) {
+            registerEvents(newEvents);
           }
         });
-      });
+        if (events) {
+          registerEvents(events);
+        }
+      } else {
+        registerEvents(events);
+      }
     };
   }]);

--- a/modules/event/test/eventSpec.js
+++ b/modules/event/test/eventSpec.js
@@ -9,7 +9,7 @@ describe('uiEvent', function () {
 
   //helper for creating event elements
   function eventElement(scope, eventObject) {
-    scope._uiEvent = eventObject || {};
+    scope._uiEvent = eventObject;
     return $compile('<span ui-event="_uiEvent">')(scope);
   }
 
@@ -73,6 +73,25 @@ describe('uiEvent', function () {
       };
       var elm = eventElement($scope, {'stuff': 'onStuff($event, $params)'});
       elm.triggerHandler('stuff', ['foo', 'bar']);
+    });
+
+    it('should work if eventObject is undefined on compile step and/or updated at runtime', function () {
+      $scope = $rootScope.$new();
+      $scope.amount = 1;
+
+      var elm = eventElement($scope);
+      elm.triggerHandler('stuff');
+      expect($scope.amount).toBe(1);
+
+      $scope._uiEvent = {'stuff': 'amount = amount + 1'};
+      $scope.$digest();
+      elm.triggerHandler('stuff');
+      expect($scope.amount).toBe(2);
+
+      $scope._uiEvent = {'stuff': 'amount = amount + 2'};
+      $scope.$digest();
+      elm.triggerHandler('stuff');
+      expect($scope.amount).toBe(4);
     });
   });
 


### PR DESCRIPTION
In case when list of events (eventObject) is undefined at compile step, events never be assigned. I've fixed this issue and also I've added opportunity to update eventObject (means reassign event list) at runtime.
