### PR TITLE
Normalizes keycode when adding it to combination.keys.

### DIFF
--- a/modules/keypress/keypress.js
+++ b/modules/keypress/keypress.js
@@ -24,7 +24,7 @@ factory('keypressHelper', ['$parse', function keypress($parse){
 
   return function(mode, scope, elm, attrs) {
     var params, combinations = [];
-    params = scope.$eval(attrs['ui'+capitaliseFirstLetter(mode)]);
+    params = scope.$eval(attrs['ui' + capitaliseFirstLetter(mode)]);
 
     // Prepare combinations for simple checking
     angular.forEach(params, function (v, k) {
@@ -37,6 +37,10 @@ factory('keypressHelper', ['$parse', function keypress($parse){
           keys: {}
         };
         angular.forEach(variation.split('-'), function (value) {
+          // Normalize keycodes.
+          if (value >= 97 && value <= 122) {
+            value = value - 32;
+          }
           combination.keys[value] = true;
         });
         combinations.push(combination);
@@ -52,14 +56,13 @@ factory('keypressHelper', ['$parse', function keypress($parse){
       var shiftPressed = !!event.shiftKey;
       var keyCode = event.keyCode;
 
-      // normalize keycodes
+      // Normalize keycodes.
       if (mode === 'keypress' && !shiftPressed && keyCode >= 97 && keyCode <= 122) {
         keyCode = keyCode - 32;
       }
 
       // Iterate over prepared combinations
       angular.forEach(combinations, function (combination) {
-
         var mainKeyPressed = combination.keys[keysByCode[keyCode]] || combination.keys[keyCode.toString()];
 
         var metaRequired = !!combination.keys.meta;

--- a/modules/keypress/test/keydownSpec.js
+++ b/modules/keypress/test/keydownSpec.js
@@ -34,11 +34,19 @@ describe('uiKeydown', function () {
     expect($scope.event).toBe(true);
   });
 
+  it('should support single key press (alphabet)', function () {
+    // Keycode 106 = 'j'; Keycode 74 = 'J'
+    // Since the keycode is normalized (i.e. a-z -> A-Z), creating an element
+    // with keycode 106 should create a key event 74 (= 106 - 32).
+    createElement({'106': 'event=true'}).trigger(createKeyEvent(74));
+    expect($scope.event).toBe(true);
+  });
+
   it('should support combined key press', function () {
     createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event).toBe(true);
   });
-  
+
   it('should support alternative combinations', function () {
     $scope.event = 0;
     createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true, false)).trigger(createKeyEvent(14, false, true, true, false));

--- a/modules/keypress/test/keypressSpec.js
+++ b/modules/keypress/test/keypressSpec.js
@@ -35,11 +35,19 @@ describe('uiKeypress', function () {
     expect($scope.event).toBe(true);
   });
 
+  it('should support single key press (alphabet)', function () {
+    // Keycode 106 = 'j'; Keycode 74 = 'J'
+    // Since the keycode is normalized (i.e. a-z -> A-Z), creating an element
+    // with keycode 106 should create a key event 74 (= 106 - 32).
+    createElement({'106': 'event=true'}).trigger(createKeyEvent(74));
+    expect($scope.event).toBe(true);
+  });
+
   it('should support combined key press', function () {
     createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event).toBe(true);
   });
-  
+
   it('should support alternative combinations', function () {
     $scope.event = 0;
     createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true, false)).trigger(createKeyEvent(14, false, true, true, false));

--- a/modules/keypress/test/keyupSpec.js
+++ b/modules/keypress/test/keyupSpec.js
@@ -34,11 +34,19 @@ describe('uiKeyup', function () {
     expect($scope.event).toBe(true);
   });
 
+  it('should support single key press (alphabet)', function () {
+    // Keycode 106 = 'j'; Keycode 74 = 'J'
+    // Since the keycode is normalized (i.e. a-z -> A-Z), creating an element
+    // with keycode 106 should create a key event 74 (= 106 - 32).
+    createElement({'106': 'event=true'}).trigger(createKeyEvent(74));
+    expect($scope.event).toBe(true);
+  });
+
   it('should support combined key press', function () {
     createElement({'ctrl-shift-13': 'event=true'}).trigger(createKeyEvent(13, false, true, true, false));
     expect($scope.event).toBe(true);
   });
-  
+
   it('should support alternative combinations', function () {
     $scope.event = 0;
     createElement({'ctrl-shift-14 ctrl-shift-13': 'event=event+1'}).trigger(createKeyEvent(13, false, true, true, false)).trigger(createKeyEvent(14, false, true, true, false));


### PR DESCRIPTION
 This fixes a bug where it doesn't catch an alphabet keypress such as 'j' or 'k'.
