### PR TITLE
Element top value now relative to viewport, instead of parent element.

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -9,7 +9,7 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
   return {
     require: '^?uiScrollfixTarget',
     link: function (scope, elm, attrs, uiScrollfixTarget) {
-      var top = elm[0].offsetTop,
+      var top = elm[0].getBoundingClientRect().top,
           $target = uiScrollfixTarget && uiScrollfixTarget.$element || angular.element($window);
       if (!attrs.uiScrollfix) {
         attrs.uiScrollfix = top;


### PR DESCRIPTION
When scrolling past an element, it would seem the top of the element needs to be relative to the viewport and not the parent element. "offsetTop" is relative to parent element, "getBoundingClientRect()" is relative to viewport. Scrolling past the top of the parent element results in the scroll fixed element being fixed prematurely if there is sibling content above it.
