### PR TITLE
Added new waypoints module

### DIFF
--- a/modules/utils.js
+++ b/modules/utils.js
@@ -13,5 +13,6 @@ angular.module('ui.utils',  [
   "ui.scrollfix",
   "ui.showhide",
   "ui.unique",
-  "ui.validate"
+  "ui.validate",
+  "ui.waypoints"
 ]);

--- a/modules/waypoints/demo/index.html
+++ b/modules/waypoints/demo/index.html
@@ -1,0 +1,72 @@
+<section id="waypoints">
+  <div class="page-header">
+    <h1>Waypoints</h1>
+  </div>
+  <div class="row">
+    <div class="span6">
+      <h3>What?</h3>
+
+      <p>Call provided functions when the specified elements transition from above the current window to above the current window, or from left to right.</p>
+
+      <script type="text/javascript">
+        function WaypointsExampleCtrl($scope) {
+          $scope.callback = function(direction, element) {
+            $scope.direction = direction;
+          }
+        }
+      </script>
+
+      <div id="waypointsExample" class="well" ng-controller="WaypointsExampleCtrl" style="height:500px">
+        <p style="height: 100px">Try scrolling past the red text or changing the offset</p>
+        <p ui-waypoints="callback" style="color: red; height: 100px">They see me scrollin...</p>
+        
+        <p id="waypointsOutput" ng-hide="direction == null">You scrolled {{direction}} past the message</p>
+      </div>
+    </div>
+    <div class="span6">
+      <h3>Why?</h3>
+
+      <p>Trigger class changes on different menu elements (e.g. in a sticky navbar) when key elements are passed, trigger animations based on page position</p>
+
+    </div>
+  </div>
+
+  <h3>How?</h3>
+
+  <h4>Define your callback function</h4>
+  <pre class="prettyprint">$scope.callback = function(direction, element) {
+    $scope.callback = function(direction, element) {
+      $scope.direction = direction;
+    };
+  }
+  </pre>
+
+  <h4>Configure ui-waypoints</h4>
+  <pre class="prettyprint">
+    &lt;p ui-waypoints="callback"&gt;They see me scrollin...&lt;/p&gt;
+    &lt;p id="waypointsOutput" ng-hide="direction == null"&gt;You scrolled {{direction}} past the message&lt;/p&gt;
+  </pre>
+  <p>The argument to ui-waypoints should be an expression that evaluates to either an object or a function.</p>
+  <p>If it is a function, the function will be called with the arguments (direction, element),
+   where direction is a string that is one of "up", "down", "left", or "right". The element
+   will be the element that triggered the callback.</p>
+  <p>
+  <p>You can optionally pass an object to waypoints <code>ui-waypoints</code>. The following options are valid:
+    <table>
+      <tr><th>Attribute</th><th>Description</th></tr>
+      <tr>
+        <td><code> enter </code></td><td> Function that is called when transition from above to below or left to right. Passed the direction (down, right), and the element. </td>
+      </tr>
+      <tr>
+        <td><code> exit </code></td><td> Function that is called when transitioning from below to above or right to left. Passed the direction (up, left), and the element.</td>
+      </tr>
+      <tr>
+        <td><code> both </code></td><td> Function that is called when transitioning in either directionPassed the direction (left, right up, down), and the element. </td>
+      </tr>
+      <tr>
+        <td><code> offset </code></td><td> Object which specifies the the detected y-offset of the element. Should be an object that looks like <code>{"vertical": 10, "horizontal":15}</code>. Values can be either absolute
+    <code>600</code> or offset from the calculated value -50 or +100. In the latter case, they should be strings, and in the former, numbers.</td>
+      </tr>
+    which would override the detected y-offset of the element. Values can be either absolute
+    <code>600</code> or offset from the calculated value <code>-50</code> or <code>+100</code>.</p>
+</section>

--- a/modules/waypoints/demo/index.html
+++ b/modules/waypoints/demo/index.html
@@ -15,11 +15,24 @@
           }
         }
       </script>
+      <style>
+        .a-class {
+          position:fixed;
+          top:50%;
+          left:0px;
+          font-weight: bold;
+          color: red;
+          background-color: grey;
+          transform:rotate(-90deg);
+          -ms-transform:rotate(-90deg); /* IE 9 */
+          -webkit-transform:rotate(-90deg); /* Safari and Chrome */
+        }
+      </style>
 
       <div id="waypointsExample" class="well" ng-controller="WaypointsExampleCtrl" style="height:500px">
         <p style="height: 100px">Try scrolling past the red text or changing the offset</p>
         <p ui-waypoints="callback" style="color: red; height: 100px">They see me scrollin...</p>
-        
+        <p ui-waypoints="'a-class'" style="100px">When you scroll past me, 'a-class' will be added to my list of classes</p>
         <p id="waypointsOutput" ng-hide="direction == null">You scrolled {{direction}} past the message</p>
       </div>
     </div>
@@ -46,27 +59,47 @@
     &lt;p ui-waypoints="callback"&gt;They see me scrollin...&lt;/p&gt;
     &lt;p id="waypointsOutput" ng-hide="direction == null"&gt;You scrolled {{direction}} past the message&lt;/p&gt;
   </pre>
-  <p>The argument to ui-waypoints should be an expression that evaluates to either an object or a function.</p>
-  <p>If it is a function, the function will be called with the arguments (direction, element),
+  <p>The argument to ui-waypoints should be one of the following:
+    <ul>
+      <li>Blank/empty</li>
+      <li>an expression that evaluates to either an object or a function.</li>
+      <li>A string of the form '+123', '-123'</li>
+      <li>An integer</li>
+      <li>A free-form string</li>
+    </ul>
+  </p>
+  <p>If the argument is blank, the class 'ui-scrollfix' will be assigned to the element whenever it is scrolled past, and removed whenever it is scrolled past in the other direction.</p>
+  <p>If it is an expression that evaluates to a function, the function will be called with the arguments (direction, element),
    where direction is a string that is one of "up", "down", "left", or "right". The element
    will be the element that triggered the callback.</p>
+  </p>
   <p>
-  <p>You can optionally pass an object to waypoints <code>ui-waypoints</code>. The following options are valid:
+      If it's an integer, or a string of the form "+123"/"-123", the class "ui-scrollfix" will be assigned to the element after the offset specified is passed. The +/- syntax implies a relative shift in the offset (more details below).
+  </p>
+  <p>If it is a string, the string will be used as the classname to assign whenever the target is scrolled past. I.e., if you provide ui-waypoints="'a-class'", 'a-class' will be added to the list of classes for the target element whenever it is scrolled past (and removed when the direction is reversed).
+  </p>
+  <p>Expressions which evaluate to objects are treated as an options object. The following options are valid:
     <table>
       <tr><th>Attribute</th><th>Description</th></tr>
       <tr>
-        <td><code> enter </code></td><td> Function that is called when transition from above to below or left to right. Passed the direction (down, right), and the element. </td>
+        <td><code> enter </code></td><td> function | Default null | Called when transition from above to below or left to right. Passed the direction (down, right), and the element. </td>
       </tr>
       <tr>
-        <td><code> exit </code></td><td> Function that is called when transitioning from below to above or right to left. Passed the direction (up, left), and the element.</td>
+        <td><code> exit </code></td><td> function | Default null | Called when transitioning from below to above or right to left. Passed the direction (up, left), and the element.</td>
       </tr>
       <tr>
-        <td><code> both </code></td><td> Function that is called when transitioning in either directionPassed the direction (left, right up, down), and the element. </td>
+        <td><code> both </code></td><td> function | Default null | Called when transitioning in either directionPassed the direction (left, right up, down), and the element. </td>
       </tr>
       <tr>
-        <td><code> offset </code></td><td> Object which specifies the the detected y-offset of the element. Should be an object that looks like <code>{"vertical": 10, "horizontal":15}</code>. Values can be either absolute
+        <td><code> offset </code></td><td> object | Default {vertical: 0, horizontal: 0} | Specifies the the detected y-offset of the element. Should be an object that looks like <code>{"vertical": 10, "horizontal":15}</code>. Values can be either absolute
     <code>600</code> or offset from the calculated value -50 or +100. In the latter case, they should be strings, and in the former, numbers.</td>
       </tr>
-    which would override the detected y-offset of the element. Values can be either absolute
-    <code>600</code> or offset from the calculated value <code>-50</code> or <code>+100</code>.</p>
+      <tr>
+        <td><code> addClass </code></td><td> string | Default null | Specifies a class to add to an element after it has been scrolled past. You may also simply specify this as the main argument to ui-waypoints, i.e., <code>&lt;p ui-waypoints="'class-name'"&gt;...&lt;/p&gt;</code> (note the extra quotes there... this can be any expression that evaluates to a string)</td>
+      </tr>
+      <tr>
+        <td><code> updateOffset </code></td><td> boolean | Default true (caveat, see description) | When true, the offset for the target element will be updated each time a scroll event occurs. Otherwise, the offset will stay fixed at the first place which the element was encountered. The default is usually true, unless you specify a classname as the primary argument (e.g., ui-waypoints="'a-class'"). This is to prevent unexpected behavior if you are using this functionality to apply position: fixed to an element.</td>
+      </tr>
+    </table>
+    </p>
 </section>

--- a/modules/waypoints/test/waypointsSpec.js
+++ b/modules/waypoints/test/waypointsSpec.js
@@ -130,7 +130,7 @@ describe('uiWaypoints', function () {
       expect(scope.g).toHaveBeenCalledWith('down', $fixture[0]);
     });
 
-it('should respect the offset parameter in the horizontal direction', function () {
+    it('should respect the offset parameter in the horizontal direction', function () {
       scope.g = function(){};
       spyOn(scope, 'g');
       scope.waypoints = {
@@ -155,6 +155,141 @@ it('should respect the offset parameter in the horizontal direction', function (
       angular.element($window).scrollLeft($fixture.offset().left - 99);
       angular.element($window).trigger('scroll');
       expect(scope.g).toHaveBeenCalledWith('right', $fixture[0]);
+    });
+
+    it('should assign the "addClass" class to the element when it is specified', function () {
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints="\'test-class\'"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top + 50);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('test-class')).toBe(true);
+
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top - 50);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('test-class')).toBe(false);
+    });
+
+    it('should assign the "addClass" class to the element when it is specified using full options syntax', function () {
+      scope.waypoints = {
+        addClass: 'test-class2'
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints="waypoints"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top + 50);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('test-class2')).toBe(true);
+
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top - 50);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('test-class2')).toBe(false);
+    });
+
+    it('should assign the "ui-scrollfix" class to the element when no arguments are passed to ', function () {
+      scope.waypoints = {
+        addClass: 'test-class2'
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints=""></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top + 50);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(true);
+
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top - 50);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+    });
+
+    it('should treat arguments that start with + as offset specification for ui-scrollfix functionality', function () {
+      scope.waypoints = {
+        addClass: 'test-class2'
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints="+100"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top + 101);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(true);
+
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top + 99);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+    });
+
+    it('should treat arguments that start with - as offset specification for ui-scrollfix functionality', function () {
+      scope.waypoints = {
+        addClass: 'test-class2'
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints="-100"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top +101);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(true);
+
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top - 101);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+    });
+
+    it('should treat numeric arguments as offset specification for ui-scrollfix functionality', function () {
+      scope.waypoints = {
+        addClass: 'test-class2'
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints="100"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top +101);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(true);
+
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top +99);
+      angular.element($window).trigger('scroll');
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
     });
 
   });

--- a/modules/waypoints/test/waypointsSpec.js
+++ b/modules/waypoints/test/waypointsSpec.js
@@ -1,0 +1,161 @@
+/*global describe, beforeEach, module, inject, it, spyOn, expect, $ */
+describe('uiWaypoints', function () {
+  'use strict';
+
+  var scope, $compile, $window, $body, $container;
+  beforeEach(module('ui.waypoints'));
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$window_) {
+    scope = _$rootScope_.$new();
+    $compile = _$compile_;
+    $window = _$window_;
+    $body = angular.element("body");
+    $body.empty();
+    $container = angular.element('<div id="container"></div>');
+    $body.append($container);
+  }));
+
+  describe('compiling this directive', function () {
+    it('should bind to window "scroll" event', function () {
+      spyOn($.fn, 'bind');
+      scope.f = function() {};
+      $compile('<div ui-waypoints="f"></div>')(scope);
+      expect($.fn.bind).toHaveBeenCalled();
+      expect($.fn.bind.mostRecentCall.args[0]).toBe('scroll');
+    });
+  });
+  describe('scrolling the window', function () {
+    it('should trigger function if a function call is specified', function () {
+      scope.f = function(){
+        return "A";
+      };
+
+      spyOn(scope, 'f');
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test1" ui-waypoints="f"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test1");
+
+      // Scroll the window to the test element
+      angular.element($window).scrollTop($fixture.offset().top + 1);
+
+      // TODO: Is there a way to synchronously wait for the scroll event to be fired by the browser here?
+      // Need to trigger it myself in the meantime
+      angular.element($window).trigger('scroll');
+      expect(scope.f).toHaveBeenCalled();
+    });
+
+    it('should call the enter function when the window transitions from above to below the element', function () {
+      scope.enter = function(){};
+      spyOn(scope, 'enter');
+
+      // Test Fixture
+      var element = angular.element('<div><div style="height:1500px"></div><div id="test2" ui-waypoints="{\'enter\': enter}"></div><div style="height:1500px"></div>');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test2");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top + 50);
+      angular.element($window).trigger('scroll');
+
+      
+      expect(scope.enter).toHaveBeenCalledWith("down", $fixture[0]);
+    });
+
+    it('should call the exit function when the window transitions from below to above the element', function () {
+      scope.g = function(){};
+      spyOn(scope, 'g');
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1500px"></div><div id="test3" ui-waypoints="{\'exit\': g}"></div><div style="height:1500px">');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test3");
+
+      // Scroll past
+      angular.element($window).scrollTop($fixture.offset().top + 50);
+      angular.element($window).trigger('scroll');
+
+      // Scroll back before
+      angular.element($window).scrollTop($fixture.offset().top - 50);
+      angular.element($window).trigger('scroll');
+
+
+      expect(scope.g).toHaveBeenCalledWith("up", $fixture[0]);
+    });
+
+    it('should call the enter function when the window transitions from left to right of element', function () {
+      scope.f = function(){};
+      spyOn(scope, 'f');
+
+      // Test Fixture
+      var element = angular.element('<div style="white-space: nowrap; width:4000px;"><span style="height:10px; width:1300px; display: inline-block;">Test1</span><span id="test4" ui-waypoints="{\'enter\': f}" style="display:inline-block; width:1200px; height: 10px">Test2</span></div>');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test4");
+
+      // Scroll past
+      angular.element($window).scrollLeft($fixture.offset().left + 50);
+      angular.element($window).trigger('scroll');
+      
+      expect(scope.f).toHaveBeenCalledWith('right', $fixture[0]);
+    });
+
+    it('should respect the offset parameter in the vertical direction', function () {
+      scope.g = function(){};
+      spyOn(scope, 'g');
+      scope.waypoints = {
+        enter: scope.g,
+        offset: {
+          vertical: "+100"
+        }
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="height:1200px"></div><div id="test5" ui-waypoints="waypoints"></div><div style="height:1200px"></div>');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test5");
+
+      // Scroll past, but not enough to trigger given the offset
+      angular.element($window).scrollTop($fixture.offset().top + 50);
+      angular.element($window).trigger('scroll');
+      expect(scope.g).not.toHaveBeenCalled();
+
+      // Now scroll past enough to trigger
+      angular.element($window).scrollTop($fixture.offset().top + 200);
+      angular.element($window).triggerHandler('scroll');
+      expect(scope.g).toHaveBeenCalledWith('down', $fixture[0]);
+    });
+
+it('should respect the offset parameter in the horizontal direction', function () {
+      scope.g = function(){};
+      spyOn(scope, 'g');
+      scope.waypoints = {
+        enter: scope.g,
+        offset: {
+          horizontal: "-100"
+        }
+      };
+
+      // Test Fixture
+      var element = angular.element('<div style="white-space: nowrap; width:4000px;"><span style="height:10px; width:1300px; display: inline-block;">Test1</span><span id="test6" ui-waypoints="waypoints" style="display:inline-block; width:1200px; height: 10px">Test2</span></div>');
+      $container.append(element);
+      $compile($body.contents())(scope);
+      var $fixture = angular.element("#test6");
+
+      // Scroll past, but not enough to trigger given the offset
+      angular.element($window).scrollLeft($fixture.offset().left - 150);
+      angular.element($window).trigger('scroll');
+      expect(scope.g).not.toHaveBeenCalled();
+
+      // Now scroll past enough to trigger
+      angular.element($window).scrollLeft($fixture.offset().left - 99);
+      angular.element($window).trigger('scroll');
+      expect(scope.g).toHaveBeenCalledWith('right', $fixture[0]);
+    });
+
+  });
+});

--- a/modules/waypoints/waypoints.js
+++ b/modules/waypoints/waypoints.js
@@ -1,0 +1,192 @@
+/**
+ * Generates an angular-aware callback when the specfied element passes the specified element.
+ * Optionally, may provide an offset to specify when the event should be thrown
+ * 
+ * This plugin is based heavily on both the ui-scrollfix plugin and inspired by the jquery
+ * waypoints plugin, https://github.com/imakewebthings/jquery-waypoints.
+ * 
+ *
+ * @param [options | callback] {object | function} Configuration options or callback function
+ *  This should be an expression that evaluates to either an object or a function. 
+ *
+ *  If it is a function, the function will be called with the arguments (direction, element),
+ *  where direction is a string that is one of "up", "down", "left", or "right". The element
+ *  will be the element that triggered the callback.
+ *
+ *  If it is an object, it is assumed to be an options object. The possible options are
+ *   - enter
+ *   - exit
+ *   - both
+ *   - offset
+ *
+ *  All of these options are described in more detail on the demo page
+ */
+angular.module('ui.waypoints',[]).directive('uiWaypoints', ['$window', "$parse", function ($window, $parse) {
+  'use strict';
+
+
+  /* Utility functions */
+
+  /* 
+   * Get current offset of the specified target element, 
+   * taking into account the offset preferences provided via the options
+   */
+  var getTargetOffsets = function(targetElement, options) {
+
+    options = options || {};
+
+    // Get the current offsets
+    var top = targetElement[0].offsetTop,
+        left = targetElement[0].offsetLeft;
+
+    // Decide on the location to trigger the events from
+    var offset = {vertical: top, horizontal: left};
+    var references = ["vertical", "horizontal"];
+
+    for(var i in references) {
+      var reference = references[i];
+      if (typeof(options.offset[reference]) === 'string') {
+        // charAt is generally faster than indexOf: http://jsperf.com/indexof-vs-charat
+        if (options.offset[reference].charAt(0) === '-') {
+          offset[reference] = offset[reference] - parseFloat(options.offset[reference].substr(1));
+        } else if (options.offset[reference].charAt(0) === '+') {
+          offset[reference] = offset[reference] + parseFloat(options.offset[reference].substr(1));
+        }
+      } else if(typeof(options.offset[reference]) === "number") {
+        offset[reference] = offset[reference] + options.offset[reference];
+      }// Offset established
+    }
+    return offset;
+  };
+
+  /*
+   * Get the location current scroll location of the window. Should be cross-browser compatible.
+   */
+  var getCurrentWindowOffsets = function() {
+
+    // if pageYOffset is defined use it, otherwise use other crap for IE
+    var xOffset, yOffset;
+    if (angular.isDefined($window.pageYOffset)) {
+      yOffset = $window.pageYOffset;
+      xOffset = $window.pageXOffset;
+    } else {
+      var iebody = (document.compatMode && document.compatMode !== "BackCompat") ? document.documentElement : document.body;
+      yOffset = iebody.scrollTop;
+      xOffset = iebody.scrollLeft;
+    }
+
+    return {
+      vertical: yOffset,
+      horizontal: xOffset
+    };
+  };
+
+
+  return {
+    require: '^?uiWaypointsTarget',
+    link: function (scope, elm, attrs, uiWaypointsTarget) {
+
+      // Decide on the options
+      var options = {
+        direction: 'vertical',
+        reference: 'top',
+        enter: null,
+        exit: null,
+        both: null
+      };
+      if(attrs.uiWaypoints == null) {
+        throw new Error("ui-waypoints requires arguments");
+      }
+
+      // Options are either an object, a function (enter callback), or an error
+      var getter = $parse(attrs.uiWaypoints);
+      var arg = getter(scope);
+      if(typeof(arg) === 'object') {
+        options = angular.extend(options,arg);
+      } else if(typeof(arg) === 'function') {
+        options.both = arg;
+      } else {
+        throw new Error("ui-waypoints requires an expression that evaluates to either a function or an object");
+      }
+
+      // Sanitize options
+      if(!options.offset) {
+        options.offset = {};
+        options.offset.vertical = 0;
+        options.offset.horizontal = 0;
+      }
+      if(options.verticalOffset) {
+        options.offset.vertical = options.verticalOffset;
+      }
+      if(options.horizontalOffset) {
+        options.offset.horizontal = options.horizontalOffset;
+      }
+
+      // This is what we will watch for scrolling events; defaults to window if not otherwise specified
+      var $target = uiWaypointsTarget && uiWaypointsTarget.$element || angular.element($window);
+
+      // We will start in the "above" state, meaning no events will be
+      // thrown until we pass the element by scrolling
+      var above = {
+        "vertical": true,
+        "horizontal": true
+      };
+
+      $target.bind('scroll', function () {
+
+
+        // Get the window offsets
+        var windowOffsets = getCurrentWindowOffsets();
+
+        // Get the current offset
+        var offset = getTargetOffsets(elm, options);
+
+        // Do callbacks
+        var directions = ["vertical","horizontal"];
+        for(var i in directions) {
+
+          var activeDirection = directions[i];
+
+          // Select the offset based on whether we're interested in vertical or horizontal
+          var currentOffset = windowOffsets[activeDirection];
+
+          var direction = null;
+          if(above[activeDirection] && currentOffset > offset[activeDirection]) {
+            direction = activeDirection === "vertical" ? "down" : "right";
+            if(options.enter) {
+              options.enter(direction, elm[0]);
+            }
+              
+            if(options.both) {
+              options.both(direction, elm[0]);
+            }
+              
+            above[activeDirection] = false;
+          } else if(!above[activeDirection] && currentOffset < offset[activeDirection]) {
+            direction = activeDirection === "vertical" ? "up" : "left";
+            if(options.exit) {
+              options.exit(direction, elm[0]);
+            }
+              
+            if(options.both){
+              options.both(direction, elm[0]);
+            }
+            above[activeDirection] = true;
+          }
+        }// for(i in directions)
+        
+        // Need this since we aren't in an angular event handler
+        if(!(scope.$$phase || scope.$root.$$phase)) {
+          scope.$apply();
+        }
+      });
+    }
+  };
+}]).directive('uiWaypointsTarget', [function () {
+  'use strict';
+  return {
+    controller: function($element) {
+      this.$element = $element;
+    }
+  };
+}]);


### PR DESCRIPTION
I needed similar functionality to what the jQuery waypoints module provides in angular. I suppose I could have used ui-jq and used waypoints itself, but I liked the idea of having a native angular way to do this, so I wrote a module to do it. I used many of the same conventions as are used in the ui-scrollfix plugin, it's just that instead of assigning a class, you get callbacks.

If it's interesting to this project, feel free to take it! If the idea is interesting in general but you need some additions/changes, I'm happy to oblige. 

Thanks,

-Matt
