### PR TITLE
Unbind uiScrollfix directive jQuery event handlers to prevent memory leaks

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -11,6 +11,7 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
     link: function (scope, elm, attrs, uiScrollfixTarget) {
       var top = elm[0].offsetTop,
           $target = uiScrollfixTarget && uiScrollfixTarget.$element || angular.element($window);
+
       if (!attrs.uiScrollfix) {
         attrs.uiScrollfix = top;
       } else if (typeof(attrs.uiScrollfix) === 'string') {
@@ -22,7 +23,7 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
         }
       }
 
-      $target.bind('scroll', function () {
+      function onScroll() {
         // if pageYOffset is defined use it, otherwise use other crap for IE
         var offset;
         if (angular.isDefined($window.pageYOffset)) {
@@ -36,6 +37,13 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
         } else if (elm.hasClass('ui-scrollfix') && offset < attrs.uiScrollfix) {
           elm.removeClass('ui-scrollfix');
         }
+      }
+
+      $target.on('scroll', onScroll);
+
+      // Unbind scroll event handler when directive is removed
+      scope.$on('$destroy', function() {
+        $target.off('scroll', onScroll);
       });
     }
   };

--- a/modules/scrollfix/test/scrollfixSpec.js
+++ b/modules/scrollfix/test/scrollfixSpec.js
@@ -11,11 +11,28 @@ describe('uiScrollfix', function () {
   }));
 
   describe('compiling this directive', function () {
-    it('should bind to window "scroll" event', function () {
-      spyOn($.fn, 'bind');
+    it('should bind and unbind to window "scroll" event in the absence of a uiScrollfixTarget', function () {
+      spyOn($.fn, 'on').andCallThrough();
       $compile('<div ui-scrollfix="100"></div>')(scope);
-      expect($.fn.bind).toHaveBeenCalled();
-      expect($.fn.bind.mostRecentCall.args[0]).toBe('scroll');
+      expect($.fn.on).toHaveBeenCalled();
+      expect($.fn.on.mostRecentCall.args[0]).toBe('scroll');
+      expect($._data($window, 'events')).toBeDefined();
+      expect($._data($window, 'events').scroll.length).toBe(1);
+      // Event must un-bind to prevent memory leaks
+      spyOn($.fn, 'off').andCallThrough();
+      scope.$destroy();
+      expect($.fn.off).toHaveBeenCalled();
+      expect($.fn.off.mostRecentCall.args[0]).toBe('scroll');
+      expect($._data($window, 'events')).toBeUndefined();
+    });
+    it('should bind and unbind to a parent uiScrollfixTarget element "scroll" event', function() {
+      var $elm = $compile('<div ui-scrollfix-target><div ui-scrollfix="100"></div></div>')(scope);
+      expect($._data($window, 'events')).toBeUndefined();
+      expect($._data($elm[0], 'events')).toBeDefined();
+      expect($._data($elm[0], 'events').scroll.length).toBe(1);
+      // Event must un-bind to prevent memory leaks
+      scope.$destroy();
+      expect($._data($elm[0], 'events')).toBeUndefined();
     });
   });
   describe('scrolling the window', function () {


### PR DESCRIPTION
The `uiScrollfix` directive will bind scroll event handlers to the window object in the absence of a parent `uiScrollfixTarget` directive. These event handlers were not removed when the directive was destroyed.

We prevent this by removing bound jQuery scroll event handlers when the scope is `$destroy`ed. Tests have been updated to verify events are correctly removed.

Resolves #119
