### PR TITLE
.bowerrc file created

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory" : "bower_components"
+}


### PR DESCRIPTION
Fix for issue #129:
**.bowerrc** file instructs bower to install dependencies in the expected **./bower_components/** directory.
