### PR TITLE
ui mask and ng required

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -78,7 +78,7 @@ angular.module('ui.mask', [])
             controller.$viewValue = value.length ? maskValue(value) : '';
             controller.$setValidity('mask', isValid);
             if (value === '' && controller.$error.required !== undefined) {
-              controller.$setValidity('required', false);
+                controller.$setValidity('required', !controller.$error.required);
             }
             return isValid ? value : undefined;
           }


### PR DESCRIPTION
ng-required='false' doesn't work correctly with ui mask, when entered a value and then clean the field. setValidity is set to required.

Thanks.
