### PR TITLE
Account for parent element offsets in scrollfix.

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -10,8 +10,12 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
     require: '^?uiScrollfixTarget',
     link: function (scope, elm, attrs, uiScrollfixTarget) {
       var top = elm[0].offsetTop,
+          curr = elm[0],
           $target = uiScrollfixTarget && uiScrollfixTarget.$element || angular.element($window);
 
+      while (curr = curr.offsetParent) {
+        top += curr.offsetTop;
+      }
       if (!attrs.uiScrollfix) {
         attrs.uiScrollfix = top;
       } else if (typeof(attrs.uiScrollfix) === 'string') {


### PR DESCRIPTION
When an ancestor of the scrollfixed element has position: relative, the value of element.offsetTop is not sufficient to determine the element's position, as it will be the offset from the relatively positioned ancestor instead of the top of the page.

This patch checks the offset of the element's ancestors, as described in http://www.quirksmode.org/js/findpos.html
