### PR TITLE
Validate against the viewValue instead of the modelValue for ui-validate-watch

### DIFF
--- a/modules/validate/test/validateSpec.js
+++ b/modules/validate/test/validateSpec.js
@@ -102,9 +102,15 @@ describe('uiValidate', function () {
     function validateWatch(watchMe) {
       return watchMe;
     }
+
     beforeEach(function(){
       scope.validateWatch = validateWatch;
     });
+
+    var sniffer;
+    beforeEach(inject(function ($sniffer) {
+      sniffer = $sniffer;
+    }));
 
     it('should watch the string and refire the single validator', function () {
       scope.watchMe = false;
@@ -112,6 +118,23 @@ describe('uiValidate', function () {
       expect(scope.form.input.$valid).toBe(false);
       expect(scope.form.input.$error.validator).toBe(true);
       scope.$apply('watchMe=true');
+      expect(scope.form.input.$valid).toBe(true);
+      expect(scope.form.input.$error.validator).toBe(false);
+    });
+
+    // This test will fail unless the validation is run against the view value and not the modelValue
+    it('should watch the string and refire the single validator against the viewValue', function () {
+      scope.watchMe = '12';
+      var inputElm = compileAndDigest('<input name="input" ng-model="value" ui-validate=" \'$value == watchMe\' " ui-validate-watch=" \'watchMe\' ">', scope);
+      
+      inputElm.val('5');
+      inputElm.trigger((sniffer.hasEvent('input') ? 'input' : 'change'));
+      
+      expect(scope.form.input.$valid).toBe(false);
+      expect(scope.form.input.$error.validator).toBe(true);
+
+      scope.$apply('watchMe="5"');
+      
       expect(scope.form.input.$valid).toBe(true);
       expect(scope.form.input.$error.validator).toBe(false);
     });

--- a/modules/validate/validate.js
+++ b/modules/validate/validate.js
@@ -64,7 +64,7 @@ angular.module('ui.validate',[]).directive('uiValidate', function () {
           {
               scope.$watch(watch, function(){
                   angular.forEach(validators, function(validatorFn){
-                      validatorFn(ctrl.$modelValue);
+                      validatorFn(ctrl.$viewValue);
                   });
               });
               return;
@@ -77,7 +77,7 @@ angular.module('ui.validate',[]).directive('uiValidate', function () {
                   scope.$watch(expression, function()
                   {
                       angular.forEach(validators, function(validatorFn){
-                          validatorFn(ctrl.$modelValue);
+                          validatorFn(ctrl.$viewValue);
                       });
                   });
               });
@@ -93,7 +93,7 @@ angular.module('ui.validate',[]).directive('uiValidate', function () {
                   if (angular.isString(expression))
                   {
                       scope.$watch(expression, function(){
-                          validators[validatorKey](ctrl.$modelValue);
+                          validators[validatorKey](ctrl.$viewValue);
                       });
                   }
 
@@ -103,7 +103,7 @@ angular.module('ui.validate',[]).directive('uiValidate', function () {
                       angular.forEach(expression, function(intExpression)
                       {
                           scope.$watch(intExpression, function(){
-                              validators[validatorKey](ctrl.$modelValue);
+                              validators[validatorKey](ctrl.$viewValue);
                           });
                       });
                   }


### PR DESCRIPTION
## Replicate Issue:

goto [Validate demo page](http://angular-ui.github.io/ui-utils/#/validate)
enter 'small' into first password box
enter 'smaller' into second password box
You will see 'Passwords do not match!'
change the first password box to 'smaller'

The now valid inputs wont be reflected as valid until the second password box is changed as the model value of the second input is undefined until the second input has a valid value.
## The Fix

Change the ui-validate-watch implementation to send the $viewValue to the validate function instead of the $modelValue

I have added a test case that will fail unless the $viewValue is used

I beleive this fixes issue #25 
