### PR TITLE
Ability to keep invalid value after blur

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -9,7 +9,8 @@ angular.module('ui.mask', [])
       '9': /\d/,
       'A': /[a-zA-Z]/,
       '*': /[a-zA-Z0-9]/
-    }
+    },
+    'clearOnBlur': true
   })
   .directive('uiMask', ['uiMaskConfig', function (maskConfig) {
     return {
@@ -94,7 +95,7 @@ angular.module('ui.mask', [])
               linkOptions = (function(original, current){
                 for(var i in original) {
                   if (Object.prototype.hasOwnProperty.call(original, i)) {
-                    if (!current[i]) {
+                    if (current[i] === undefined) {
                       current[i] = angular.copy(original[i]);
                     } else {
                       angular.extend(current[i], original[i]);
@@ -277,11 +278,15 @@ angular.module('ui.mask', [])
           }
 
           function blurHandler(){
-            oldCaretPosition = 0;
-            oldSelectionLength = 0;
+            if (linkOptions.clearOnBlur) {
+              oldCaretPosition = 0;
+              oldSelectionLength = 0;
+            }
             if (!isValid || value.length === 0) {
-              valueMasked = '';
-              iElement.val('');
+              if (linkOptions.clearOnBlur) {
+                valueMasked = '';
+                iElement.val('');
+              }
               scope.$apply(function (){
                 controller.$setViewValue('');
               });

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -245,6 +245,38 @@ describe("uiMask", function () {
       input.triggerHandler("blur");
       expect(scope.test.input.$viewValue).toBe("");
     });
+
+    var inputHtmlClearOnBlur = "<input name='input' ng-model='x' ui-mask='{{mask}}' ui-options=\"input.options\">";
+
+    it("should not clear an invalid value if clearOnBlur is false", function() {
+      scope.input = {
+        options: {clearOnBlur: false}
+      };
+
+      var input = compileElement(inputHtmlClearOnBlur);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '(9) * A'");
+
+      input.val("9a").triggerHandler("input");
+      input.triggerHandler("blur");
+      expect(input.val()).toBe("(9) a _");
+    });
+
+    it("should clear an invalid value if clearOnBlur is true", function() {
+      scope.input = {
+        options: {clearOnBlur: true}
+      };
+
+      var input = compileElement(inputHtmlClearOnBlur);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '(9) * A'");
+
+      input.val("9a").triggerHandler("input");
+      input.triggerHandler("blur");
+      expect(input.val()).toBe("");
+    });
   });
 
 });


### PR DESCRIPTION
When user leaves partly filled field with masked input, ui-mask automatically clears input. So user forced to fill the field twice.

This pull request adds ability to disable erasing value on blur event without breaking backward compatibility.

Behavior can be replaced locally for one input:

``` js
app.controller("FooCtrl", function($scope) {
    $scope.uiOptions = {
        clearOnBlur: false;
    };
});
```

``` html
<input ng-controller="FooCtrl" type="text" ng-model="foobar" 
       ui-mask="99.99.9999" ui-options="uiOptions" />
```

Or globally for all masked inputs:

``` js
app.config(["$provide", function($provide) {
    $provide.decorator("uiMaskConfig", ["$delegate", function($delegate) {
        $delegate.clearOnBlur = false;
        return $delegate;
    }]);
}]);
```

``` html
<input ng-controller="FooCtrl" type="text" ng-model="foobar" 
       ui-mask="99.99.9999" />
```
