### PR TITLE
Add key code 10 for 'enter'

### DIFF
--- a/modules/keypress/keypress.js
+++ b/modules/keypress/keypress.js
@@ -5,6 +5,7 @@ factory('keypressHelper', ['$parse', function keypress($parse){
   var keysByCode = {
     8: 'backspace',
     9: 'tab',
+    10: 'enter',
     13: 'enter',
     27: 'esc',
     32: 'space',


### PR DESCRIPTION
[Stack Overflow reference](http://stackoverflow.com/a/9343095)

I ran into this issue while trying to bind `ui-keypress` to `'ctrl-enter'`.

I read the contributing guidelines and tried format my commit message accordingly, but let me know if I missed anything.
