### PR TITLE
ui-I18n Proposal

### DIFF
--- a/modules/i18n/test/i18nSpec.js
+++ b/modules/i18n/test/i18nSpec.js
@@ -1,0 +1,39 @@
+/*describe('i18n', function() {
+	'use strict';
+	var uiI18n, element;
+	beforeEach(function(){
+		uiI18n = angular.module('ui.i18n');
+		uiI18n.add(['en', 'en-us'],{
+			groupPanel:{
+				testingMerge: 'some text',
+				otherText: 'some other group property text',
+				description:'Drag a column header here and drop it to group by that column.'
+			},
+			example: 'I speak English',
+			anotherExample: 'I speak A Different Language'
+		});
+		uiI18n.add('de',{
+			groupPanel:{
+				otherText: 'eine andere gruppe eigenschaft text',
+				description:'Ziehen Sie eine Spaltenuberschrift hierhin um nach dieser Spalte zu gruppieren.'
+			},
+			example: 'Ich spreche Deutsch'
+		});
+		uiI18n.add('de',{
+			groupPanel:{
+				testingMerge: 'falaffels are spelled horribly...',
+			},
+			anotherExample: 'I speak A Different Language'
+		});
+		uiI18n.set('en-us');
+	});
+
+    it('should translate', function () {
+	    inject(function ($rootScope, $compile) {
+	        element = $compile('<p ui-t="groupPanel.otherText"></p>')($rootScope);
+			console.log(element);
+			expect(element.html()).toBe('some other group property text');
+		});
+	});
+});
+*/

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -1,0 +1,93 @@
+/**
+ * Created by Tim on 2/1/14.
+ */
+(function(){
+    'use strict';
+    var MISSING = "[MISSING]: ";
+    var uiI18n = angular.module('ui.i18n', []);
+    uiI18n.value('uiI18n.packs', {
+        i18n: {},
+        lang: null
+    });
+    var getPack = function(){
+        return angular.injector(['ng','ui.i18n']).get('uiI18n.packs');
+    };
+    uiI18n.i18n = {
+        add: function(langs, strings){
+            var packs = getPack();
+            if (typeof(langs) === "object"){
+                angular.forEach(langs, function(lang){
+                    if (lang){
+                        var lower = lang.toLowerCase();
+                        var combined = angular.extend(packs.i18n[lang] || {}, strings);
+                        packs.i18n[lower] = combined;
+                    }
+                });
+            } else {
+                var lower = langs.toLowerCase();
+                var combined = angular.extend(packs.i18n[langs] || {}, strings);
+                packs.i18n[lower] = combined;
+            }
+            uiI18n.value('uiI18n.packs', packs);
+        },
+        set: function(lang){
+            if (lang){
+                var pack = getPack();
+                pack.lang = lang;
+                uiI18n.value('uiI18n.packs', pack);
+            }
+        }
+    };
+
+    uiI18n.directive('uiI18n',['uiI18n.packs', function(packs) {
+        return {
+            link: function($scope, $elm, $attrs) {
+                // check for watchable property
+                var lang = $scope.$eval($attrs.uiI18n);
+                if (lang){
+                    $scope.$watch($attrs.uiI18n, function(newLang){
+                        uiI18n.i18n.set(newLang);
+                        $scope.$broadcast("$uiI18n", newLang);
+                    });
+                } else {
+                    // fall back to the string value
+                    lang = $attrs.uiI18n;
+                }
+                uiI18n.i18n.set(lang);
+            }
+        };
+    }]);
+
+    var uitDirective = function($parse, packs) {
+        return {
+            restrict: 'EA',
+            compile: function(){
+                return function($scope, $elm, $attrs) {
+                    var token = $attrs.uiT || $attrs.uiTranslate || $elm.html();
+                    var getter = $parse(token);
+                    var missing = MISSING + token;
+
+                    var listener = $scope.$on("$uiI18n", function(evt, lang){
+                        // set text based on i18n current language
+                        $elm.html(getter(packs.i18n[lang]) || missing);
+                    });
+                    $scope.$on('$destroy', listener);
+                };
+            }
+        };
+    };
+    // directive syntax
+    uiI18n.directive('uiT',['$parse', 'uiI18n.packs', uitDirective]);
+    uiI18n.directive('uiTranslate',['$parse', 'uiI18n.packs', uitDirective]);
+
+    var uitFilter = function($parse, packs) {
+        return function(data) {
+            var getter = $parse(data);
+            // set text based on i18n current language
+            return getter(packs.i18n[packs.lang]) || MISSING + data;
+        };
+    };
+    // optional syntax
+    uiI18n.filter('t', ['$parse', 'uiI18n.packs', uitFilter]);
+    uiI18n.filter('translate', ['$parse', 'uiI18n.packs', uitFilter]);
+})();

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -256,7 +256,7 @@
     angular.forEach(FILTER_ALIASES, function(alias){
         uiI18n.filter(alias,['$parse', uitFilter]);
     });
-    angular.service('$i18nService', function(){
+    uiI18n.service('$i18nService', function(){
         var uii18nService = {
             getCache: function(){
                 return uiI18n._cache;

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -2,7 +2,7 @@
  * Created by Tim on 2/1/14.
  */
 (function(){
-
+    'use strict'
     // adding deep copy method until angularjs supports deep copy like everyone else.
     // https://github.com/angular/angular.js/pull/5059
     function deepExtend(destination, source) {
@@ -10,7 +10,7 @@
             if (source[property] && source[property].constructor &&
                 source[property].constructor === Object) {
                 destination[property] = destination[property] || {};
-                arguments.callee(destination[property], source[property]);
+                arguments.callee(destination[property], source[property]); // jshint ignore:line
             } else {
                 destination[property] = source[property];
             }

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -2,7 +2,7 @@
  * Created by Tim on 2/1/14.
  */
 (function(){
-    'use strict'
+    'use strict';
     // adding deep copy method until angularjs supports deep copy like everyone else.
     // https://github.com/angular/angular.js/pull/5059
     function deepExtend(destination, source) {
@@ -10,7 +10,9 @@
             if (source[property] && source[property].constructor &&
                 source[property].constructor === Object) {
                 destination[property] = destination[property] || {};
-                arguments.callee(destination[property], source[property]); // jshint ignore:line
+                /* jshint ignore:start */
+                arguments.callee(destination[property], source[property]);
+                /* jshint ignore:end */
             } else {
                 destination[property] = source[property];
             }

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -3,6 +3,25 @@
  * https://github.com/timothyswt
  * MIT License
  */
+ /**
+ * @ngdoc directive
+ * @name ui-i18n
+ * @requires $parse
+ *
+ * @description
+ * Allows you to localize your project by being able to specify a language on any root-ish element
+ * this can be a bindable property or the string.
+ * if bound it will automatically update all children when update.
+ * @example
+ <example module="uiI18n">
+ <file name="index.html">
+     <body ng-controller="main" ui-i18n="language">
+
+     </body>
+ </file>
+ </example>
+ */
+
 (function(deepExtend){
     'use strict';
     var MISSING = '[MISSING]: ',
@@ -83,7 +102,106 @@
         };
     };
     uiI18n.directive(LOCALE_DIRECTIVE_ALIAS, localeDirective);
+/**
+ *  * @ngdoc directive
+ * @name ui-t,ui-Translate
+ * @requires $parse
+ *
+ * @description
+ * specify the i18n string to use
+ * this can be a bindable property, expression/partial expression, or the object token.
+ * @example
+<example module="uiI18n">
+    <file name="index.html">
+        <div ng-controller="main" ui-i18n="language">
+            <div>
+                <button ng-click="changeDesc()">change Desc</button>
+                <span ui-t="groupPanel.{{desc}}"></span>
+            </div>
 
+            <p ui-t="example"></p>
+
+            <p ui-t>groupPanel.testingMerge</p>
+
+            <p ui-t>example</p>
+
+            <p ui-t="invalid.translation.path"></p>
+
+            <p ui-t>invalid.path</p>
+
+            <p ui-t>invalid.translation.again</p>
+
+
+            <h3>Using element:</h3>
+            <ui-t>example</ui-t>
+            <br/>
+            <ui-translate>groupPanel.description</ui-translate>
+            <br/>
+            <ui-t>invalid.path</ui-t>
+            <br/>
+            <ui-t>invalid.translation.again</ui-t>
+
+            <h3>Using Translate Filters:</h3>
+
+            <p>{{"groupPanel.description" | t}}</p>
+
+            <p>{{"example" | t}}</p>
+            <p>{{"invalid.path" | t}}</p>
+
+            <p>{{"invalid.translation.again" | translate}}</p>
+        </div>
+    </file>
+    <file name="script.js">
+    var app = angular.module('app', ['ui.i18n']);
+
+    app.controller('main', ['$scope', function($scope){
+        $scope.language = "en";
+        $scope.hello = "ui-i18n Example";
+        $scope.desc = "description";
+        $scope.changeLanguage = function(){
+          $scope.language = $scope.language == "de" ? "en" : "de";
+        };
+        $scope.changeDesc = function(){
+          $scope.desc = $scope.desc == "description" ? "otherText" : "description";
+        };
+    }]);
+    //Declare your i18n strings, this is enclosed in order to show that this can be done anywhere in the application
+     (function(){
+        var uiI18n = angular.module('ui.i18n');
+        uiI18n.add(["en", "en-us"],{
+            groupPanel:{
+            testingMerge: 'some text',
+            otherText: 'some other group property text',
+            description:'Drag a column header here and drop it to group by that column.'
+        },
+        example: "I speak English",
+        anotherExample: "I speak A Different Language"
+        });
+     })();
+
+     (function(){
+        var uiI18n = angular.module('ui.i18n');
+        uiI18n.add("de",{
+            groupPanel:{
+                otherText: 'eine andere gruppe eigenschaft text',
+                description:'Ziehen Sie eine Spaltenüberschrift hierhin um nach dieser Spalte zu gruppieren.'
+            },
+            example: "Ich spreche Deutsch"
+        });
+     })();
+
+     (function(){
+        var uiI18n = angular.module('ui.i18n');
+        uiI18n.add("de",{
+            groupPanel:{
+                testingMerge: 'falaffels are spelled horribly...',
+            },
+            anotherExample: "I speak A Different Language"
+        });
+     })();
+    </file>
+</example>
+ **/
     // directive syntax
     var uitDirective = function($parse) {
         return {

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -1,32 +1,23 @@
 /**
- * Created by Tim on 2/1/14.
+ * ui-i18n Created by Tim Sweet on 2/1/14.
+ * https://github.com/timothyswt
+ * MIT License
  */
-(function(){
+(function(deepExtend){
     'use strict';
-    // adding deep copy method until angularjs supports deep copy like everyone else.
-    // https://github.com/angular/angular.js/pull/5059
-    function deepExtend(destination, source) {
-        for (var property in source) {
-            if (source[property] && source[property].constructor &&
-                source[property].constructor === Object) {
-                destination[property] = destination[property] || {};
-                /* jshint ignore:start */
-                arguments.callee(destination[property], source[property]);
-                /* jshint ignore:end */
-            } else {
-                destination[property] = source[property];
-            }
-        }
-        return destination;
-    }
-    'use strict';
-    var MISSING = '[MISSING]: ';
-    var uiI18n = angular.module('ui.i18n', []);
+    var MISSING = '[MISSING]: ',
+        UPDATE_EVENT = '$uiI18n',
+        FILTER_ALIASES = ['t', 'translate'],
+        DIRECTIVE_ALIASES = ['uiT', 'uiTranslate'],
+        LOCALE_DIRECTIVE_ALIAS = 'uiI18n',
+        // default to english
+        DEFAULT_LANG = 'en-US',
+        langCache = {
+            _langs: {},
+            current: null
+        },
+        uiI18n = angular.module('ui.i18n', []);
 
-    var langCache = {
-        _langs: {},
-        current: null
-    };
     langCache.get = function(lang){
         return langCache._langs[lang.toLowerCase()];
     };
@@ -45,7 +36,7 @@
     uiI18n._cache = langCache;
     uiI18n.$broadcast = function(lang){
         if (lang && this.$root){
-            uiI18n.$root.$broadcast('$uiI18n', lang);
+            uiI18n.$root.$broadcast(UPDATE_EVENT, lang);
         }
     };
     uiI18n.add =  function(langs, strings){
@@ -66,45 +57,67 @@
         }
     };
 
-    uiI18n.directive('uiI18n',function() {
+    var localeDirective = function() {
         return {
-            link: function($scope, $elm, $attrs) {
-                if (!uiI18n.$root) uiI18n.$root = $scope.$root;
-                // check for watchable property
-                var lang = $scope.$eval($attrs.uiI18n);
-                if (lang){
-                    $scope.$watch($attrs.uiI18n, uiI18n.set);
-                } else {
-                    // fall back to the string value
-                    lang = $attrs.uiI18n;
+            compile: function(){
+                return {
+                    pre: function($scope, $elm, $attrs) {
+                        var alias = LOCALE_DIRECTIVE_ALIAS;
+                        if (!uiI18n.$root) uiI18n.$root = $scope.$root;
+                        // check for watchable property
+                        var lang = $scope.$eval($attrs[alias]);
+                        if (lang){
+                            $scope.$watch($attrs[alias], uiI18n.set);
+                        } else if ($attrs.$$observers){
+                            $scope.$on('$destroy', $attrs.$observe(alias, uiI18n.set));
+                        } else {
+                            // fall back to the string value
+                            lang = $attrs[alias];
+                        }
+                        uiI18n.set(lang || DEFAULT_LANG);
+                    }
                 }
-                uiI18n.set(lang);
             }
         };
-    });
+    };
+    uiI18n.directive(LOCALE_DIRECTIVE_ALIAS, localeDirective);
 
     // directive syntax
     var uitDirective = function($parse) {
         return {
             restrict: 'EA',
             compile: function(){
-                return function($scope, $elm, $attrs) {
-                    if (!uiI18n.$root) uiI18n.$root = $scope.$root;
-                    var token = $attrs.uiT || $attrs.uiTranslate || $elm.html();
-                    var getter = $parse(token);
-                    var missing = MISSING + token;
-
-                    var listener = $scope.$on('$uiI18n', function(evt, lang){
-                        // set text based on i18n current language
-                        $elm.html(getter(langCache.get(lang)) || missing);
-                    });
-                    $scope.$on('$destroy', listener);
-                };
+                return {
+                    pre: function($scope, $elm, $attrs) {
+                        if (!uiI18n.$root) uiI18n.$root = $scope.$root;
+                        var alias1 = DIRECTIVE_ALIASES[0],
+                            alias2 = DIRECTIVE_ALIASES[1];
+                        var token = $attrs[alias1] || $attrs[alias2] || $elm.html();
+                        var missing = MISSING + token;
+                        var observer;
+                        if ($attrs.$$observers){
+                            var prop = $attrs[alias1] ? alias1 : alias2;
+                            observer = $attrs.$observe(prop, function(result){
+                                if (result){
+                                    $elm.html($parse(result)(langCache.getCurrent()) || missing);
+                                }
+                            });
+                        }
+                        var getter = $parse(token);
+                        var listener = $scope.$on(UPDATE_EVENT, function(evt, lang){
+                            if (observer){
+                                observer($attrs[alias1] || $attrs[alias2]);
+                            } else {
+                                // set text based on i18n current language
+                                $elm.html(getter(langCache.get(lang)) || missing);
+                            }
+                        });
+                        $scope.$on('$destroy', listener);
+                    }
+                }
             }
         };
     };
-    uiI18n.directive('uiT',['$parse', uitDirective]);
-    uiI18n.directive('uiTranslate',['$parse', uitDirective]);
 
     // optional filter syntax
     var uitFilter = function($parse) {
@@ -114,6 +127,24 @@
             return getter(langCache.getCurrent()) || MISSING + data;
         };
     };
-    uiI18n.filter('t', ['$parse', uitFilter]);
-    uiI18n.filter('translate', ['$parse', uitFilter]);
-})();
+
+    angular.forEach(DIRECTIVE_ALIASES, function(alias){
+        uiI18n.directive(alias,['$parse', uitDirective]);
+    });
+    angular.forEach(FILTER_ALIASES, function(alias){
+        uiI18n.filter(alias,['$parse', uitFilter]);
+    });
+})(function(destination, source) {
+    // adding deep copy method until angularjs supports deep copy like everyone else.
+    // https://github.com/angular/angular.js/pull/5059
+    for (var property in source) {
+        if (source[property] && source[property].constructor &&
+            source[property].constructor === Object) {
+            destination[property] = destination[property] || {};
+            arguments.callee(destination[property], source[property]);
+        } else {
+            destination[property] = source[property];
+        }
+    }
+    return destination;
+});

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -63,7 +63,9 @@
                 return {
                     pre: function($scope, $elm, $attrs) {
                         var alias = LOCALE_DIRECTIVE_ALIAS;
-                        if (!uiI18n.$root) uiI18n.$root = $scope.$root;
+                        if (!uiI18n.$root){
+                            uiI18n.$root = $scope.$root;
+                        }
                         // check for watchable property
                         var lang = $scope.$eval($attrs[alias]);
                         if (lang){
@@ -89,7 +91,9 @@
             compile: function(){
                 return {
                     pre: function($scope, $elm, $attrs) {
-                        if (!uiI18n.$root) uiI18n.$root = $scope.$root;
+                        if (!uiI18n.$root){
+                            uiI18n.$root = $scope.$root;
+                        }
                         var alias1 = DIRECTIVE_ALIASES[0],
                             alias2 = DIRECTIVE_ALIASES[1];
                         var token = $attrs[alias1] || $attrs[alias2] || $elm.html();
@@ -134,7 +138,7 @@
     angular.forEach(FILTER_ALIASES, function(alias){
         uiI18n.filter(alias,['$parse', uitFilter]);
     });
-})(function(destination, source) {
+})(function deepExtend(destination, source) {
     'user strict';
     // adding deep copy method until angularjs supports deep copy like everyone else.
     // https://github.com/angular/angular.js/pull/5059
@@ -142,7 +146,7 @@
         if (source[property] && source[property].constructor &&
             source[property].constructor === Object) {
             destination[property] = destination[property] || {};
-            arguments.callee(destination[property], source[property]);
+            deepExtend(destination[property], source[property]);
         } else {
             destination[property] = source[property];
         }

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -256,7 +256,7 @@
     angular.forEach(FILTER_ALIASES, function(alias){
         uiI18n.filter(alias,['$parse', uitFilter]);
     });
-    angular.service("$i18nService", function(){
+    angular.service('$i18nService', function(){
         var uii18nService = {
             getCache: function(){
                 return uiI18n._cache;

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -139,7 +139,7 @@
         uiI18n.filter(alias,['$parse', uitFilter]);
     });
 })(function deepExtend(destination, source) {
-    'user strict';
+    'use strict';
     // adding deep copy method until angularjs supports deep copy like everyone else.
     // https://github.com/angular/angular.js/pull/5059
     for (var property in source) {

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -256,6 +256,23 @@
     angular.forEach(FILTER_ALIASES, function(alias){
         uiI18n.filter(alias,['$parse', uitFilter]);
     });
+    angular.service("$i18nService", function(){
+        var uii18nService = {
+            getCache: function(){
+                return uiI18n._cache;
+            },
+            $broadcast: function(){
+                uiI18n.$broadcast(arguments);
+            },
+            add: function(langs, strings){
+                uiI18n.add(langs, strings);
+            },
+            set: function(lang){
+                uiI18n.set(lang);
+            }
+        };
+        return uii18nService;
+    });
 })(function deepExtend(destination, source) {
     'use strict';
     // adding deep copy method until angularjs supports deep copy like everyone else.

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -3,7 +3,7 @@
  */
 (function(){
     'use strict';
-    var MISSING = "[MISSING]: ";
+    var MISSING = '[MISSING]: ';
     var uiI18n = angular.module('ui.i18n', []);
     uiI18n.value('uiI18n.packs', {
         i18n: {},
@@ -15,7 +15,7 @@
     uiI18n.i18n = {
         add: function(langs, strings){
             var packs = getPack();
-            if (typeof(langs) === "object"){
+            if (typeof(langs) === 'object'){
                 angular.forEach(langs, function(lang){
                     if (lang){
                         var lower = lang.toLowerCase();
@@ -39,7 +39,7 @@
         }
     };
 
-    uiI18n.directive('uiI18n',['uiI18n.packs', function(packs) {
+    uiI18n.directive('uiI18n',function() {
         return {
             link: function($scope, $elm, $attrs) {
                 // check for watchable property
@@ -47,7 +47,7 @@
                 if (lang){
                     $scope.$watch($attrs.uiI18n, function(newLang){
                         uiI18n.i18n.set(newLang);
-                        $scope.$broadcast("$uiI18n", newLang);
+                        $scope.$broadcast('$uiI18n', newLang);
                     });
                 } else {
                     // fall back to the string value
@@ -56,7 +56,7 @@
                 uiI18n.i18n.set(lang);
             }
         };
-    }]);
+    });
 
     var uitDirective = function($parse, packs) {
         return {
@@ -67,7 +67,7 @@
                     var getter = $parse(token);
                     var missing = MISSING + token;
 
-                    var listener = $scope.$on("$uiI18n", function(evt, lang){
+                    var listener = $scope.$on('$uiI18n', function(evt, lang){
                         // set text based on i18n current language
                         $elm.html(getter(packs.i18n[lang]) || missing);
                     });

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -5,36 +5,40 @@
     'use strict';
     var MISSING = '[MISSING]: ';
     var uiI18n = angular.module('ui.i18n', []);
-    uiI18n.value('uiI18n.packs', {
+
+    uiI18n.value('uiI18n.pack', {
         i18n: {},
         lang: null
     });
+    var injector = angular.injector(['ng','ui.i18n']);
     var getPack = function(){
-        return angular.injector(['ng','ui.i18n']).get('uiI18n.packs');
+        return injector.get('uiI18n.pack');
     };
+    var $root;
     uiI18n.i18n = {
         add: function(langs, strings){
-            var packs = getPack();
+            var pack = getPack();
             if (typeof(langs) === 'object'){
                 angular.forEach(langs, function(lang){
                     if (lang){
                         var lower = lang.toLowerCase();
-                        var combined = angular.extend(packs.i18n[lang] || {}, strings);
-                        packs.i18n[lower] = combined;
+                        var combined = angular.extend(pack.i18n[lang] || {}, strings);
+                        pack.i18n[lower] = combined;
                     }
                 });
             } else {
                 var lower = langs.toLowerCase();
-                var combined = angular.extend(packs.i18n[langs] || {}, strings);
-                packs.i18n[lower] = combined;
+                var combined = angular.extend(pack.i18n[langs] || {}, strings);
+                pack.i18n[lower] = combined;
             }
-            uiI18n.value('uiI18n.packs', packs);
+            uiI18n.value('uiI18n.pack', pack);
         },
         set: function(lang){
             if (lang){
                 var pack = getPack();
                 pack.lang = lang;
-                uiI18n.value('uiI18n.packs', pack);
+                uiI18n.value('uiI18n.pack', pack);
+                if ($root) $root.$broadcast('$uiI18n', lang);
             }
         }
     };
@@ -45,10 +49,7 @@
                 // check for watchable property
                 var lang = $scope.$eval($attrs.uiI18n);
                 if (lang){
-                    $scope.$watch($attrs.uiI18n, function(newLang){
-                        uiI18n.i18n.set(newLang);
-                        $scope.$broadcast('$uiI18n', newLang);
-                    });
+                    $scope.$watch($attrs.uiI18n, uiI18n.i18n.set);
                 } else {
                     // fall back to the string value
                     lang = $attrs.uiI18n;
@@ -58,18 +59,21 @@
         };
     });
 
-    var uitDirective = function($parse, packs) {
+    var uitDirective = function($parse, pack) {
         return {
             restrict: 'EA',
             compile: function(){
                 return function($scope, $elm, $attrs) {
+                    // this is such a hack! I tried injector invoke $rootScope but its not the right one!
+                    // TODO: make this not stupid...
+                    if (!$root) $root = $scope.$root;
                     var token = $attrs.uiT || $attrs.uiTranslate || $elm.html();
                     var getter = $parse(token);
                     var missing = MISSING + token;
 
                     var listener = $scope.$on('$uiI18n', function(evt, lang){
                         // set text based on i18n current language
-                        $elm.html(getter(packs.i18n[lang]) || missing);
+                        $elm.html(getter(pack.i18n[lang]) || missing);
                     });
                     $scope.$on('$destroy', listener);
                 };
@@ -77,17 +81,17 @@
         };
     };
     // directive syntax
-    uiI18n.directive('uiT',['$parse', 'uiI18n.packs', uitDirective]);
-    uiI18n.directive('uiTranslate',['$parse', 'uiI18n.packs', uitDirective]);
+    uiI18n.directive('uiT',['$parse', 'uiI18n.pack', uitDirective]);
+    uiI18n.directive('uiTranslate',['$parse', 'uiI18n.pack', uitDirective]);
 
-    var uitFilter = function($parse, packs) {
+    var uitFilter = function($parse, pack) {
         return function(data) {
             var getter = $parse(data);
             // set text based on i18n current language
-            return getter(packs.i18n[packs.lang]) || MISSING + data;
+            return getter(pack.i18n[pack.lang]) || MISSING + data;
         };
     };
     // optional syntax
-    uiI18n.filter('t', ['$parse', 'uiI18n.packs', uitFilter]);
-    uiI18n.filter('translate', ['$parse', 'uiI18n.packs', uitFilter]);
+    uiI18n.filter('t', ['$parse', 'uiI18n.pack', uitFilter]);
+    uiI18n.filter('translate', ['$parse', 'uiI18n.pack', uitFilter]);
 })();

--- a/modules/i18n/ui-i18n.js
+++ b/modules/i18n/ui-i18n.js
@@ -76,7 +76,7 @@
                         }
                         uiI18n.set(lang || DEFAULT_LANG);
                     }
-                }
+                };
             }
         };
     };
@@ -114,7 +114,7 @@
                         });
                         $scope.$on('$destroy', listener);
                     }
-                }
+                };
             }
         };
     };
@@ -135,6 +135,7 @@
         uiI18n.filter(alias,['$parse', uitFilter]);
     });
 })(function(destination, source) {
+    'user strict';
     // adding deep copy method until angularjs supports deep copy like everyone else.
     // https://github.com/angular/angular.js/pull/5059
     for (var property in source) {


### PR DESCRIPTION
due to the verbose nature of a couple of the i18n libraries out there and working on ng-grid 3.0 and wanting a lightweight version of i18n support I created a module that seems to be fairly lightweight and performant.

you can compare the performance of thousands of bindings against angular-translate here:

[angular-translate 11K rows of bindings](http://jsfiddle.net/eUGWJ/70/)

[ui-i18n 14K rows of bindings](http://jsfiddle.net/mc66U/5/)

setup:

``` javascript
var uiI18n = angular.module('ui.i18n');
// adding english here, the array specifies all the matchable languages for the strings.
uiI18n.add(["en", "en-us"],{
    groupPanel:{
        description:'Drag a column header here and drop it to group by that column.'
    },
    example: "I speak English"
});
uiI18n.add("de",{
    groupPanel:{
        description:'Ziehen Sie eine Spaltenüberschrift hierhin um nach dieser Spalte zu gruppieren.'
    },
    example: "I speak Something Else"
});
```

NOTE: you can lazy load strings and it will extend the current set of strings with the new ones

``` javascript
var uiI18n = angular.module('ui.i18n');
//calling this later:
uiI18n.add(["en", "en-us"],{
    groupPanel: {
        otherText: 'some other group property text'
    },
    anotherExample: "I speak A Different Language"
});
// results in 
"en"/"en-us": {
    groupPanel:{
        otherText: 'some other group property text',
        description:'Drag a column header here and drop it to group by that column.'
    },
    example: "I speak English",
    anotherExample: "I speak A Different Language"
}
```

You can set the language via directive 

``` html
<!-- directly-->
<body ui-i18n="en">
<!-- or via bindable $scope property-->
<body ui-i18n="bindableProperty">
```

Or, through a module method:

``` javascript
angular.module('ui.i18n').set("en-us");
```

Usage:
You can use it as an attribute, element, or filter, see all the different possibilities below 

``` html
 <h3>Using attribute:</h3>
    <p ui-t="groupPanel.description"></p>

    <p ui-t="example"></p>

    <p ui-t>groupPanel.description</p>

    <p ui-t>example</p>

    <p ui-t="invalid.translation.path"></p>

    <p ui-t>invalid.path</p>

    <p ui-t>invalid.translation.again</p>


    <h3>Using element:</h3>
    <ui-t>example</ui-t>
    <br/>
    <ui-translate>groupPanel.description</ui-translate>
    <br/>
    <ui-t>invalid.path</ui-t>
    <br/>
    <ui-t>invalid.translation.again</ui-t>

    <h3>Using Translate Filters:</h3>

    <p>{{"groupPanel.description" | t}}</p>

    <p>{{"example" | t}}</p>
    <p>{{"invalid.path" | t}}</p>

    <p>{{"invalid.translation.again" | translate}}</p>
```

Bonus:
{{}} expressions work in the directive syntax also.
Caveat, this does impact performance a little bit.. even using this syntax its still about 2-3x faster than angular-translate with a similar amount of rows but you should know.

``` html
 <p ui-t="groupPanel.{{desc}}"></p>
```

it will alert you to missing translations with "[MISSING]: invalid.path" in place of where the translations should be.

All feedback is greatly appreciated.

here is a plunk for your enjoyment:
[ui-i18n plunk](http://plnkr.co/LrWPGJ?p=preview)
