### PR TITLE
A fix for #83, highlight regexp needs to be escaped

### DIFF
--- a/modules/highlight/highlight.js
+++ b/modules/highlight/highlight.js
@@ -14,7 +14,7 @@ angular.module('ui.highlight',[]).filter('highlight', function () {
       if (caseSensitive) {
         return text.split(search).join('<span class="ui-match">' + search + '</span>');
       } else {
-        return text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>');
+        return text.replace(new RegExp(search.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'), 'gi'), '<span class="ui-match">$&</span>');
       }
     } else {
       return text;

--- a/modules/highlight/test/highlightSpec.js
+++ b/modules/highlight/test/highlightSpec.js
@@ -23,6 +23,9 @@ describe('highlight', function () {
     it('should work correctly for number text', function () {
       expect(highlightFilter(3210123, '0')).toEqual('321<span class="ui-match">0</span>123');
     });
+    it('should work correctly for text containing regex literals', function () {
+      expect(highlightFilter('Prefix question? Suffix', '?')).toEqual('Prefix question<span class="ui-match">?</span> Suffix');
+    });
   });
   describe('case sensitive', function () {
     it('should highlight a matching phrase', function () {


### PR DESCRIPTION
We wish to use the highlight directive in a project I'm working on right now, but have run into issues with strings containing regexp literals (.$? etc.). This fixes the issue by escaping such characters.
