### PR TITLE
Option to let the mask return it's view value. And removed unwarranted responsibility

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -29,7 +29,9 @@ angular.module('ui.mask', [])
             originalPlaceholder = iAttrs.placeholder,
             originalMaxlength = iAttrs.maxlength,
           // Vars used exclusively in eventHandler()
-            oldValue, oldValueUnmasked, oldCaretPosition, oldSelectionLength;
+            oldValue, oldValueUnmasked, oldCaretPosition, oldSelectionLength,
+          // Vars for defining wether to return parsed value or viewValue
+            useViewValue;
 
           function initialize(maskAttr){
             if (!angular.isDefined(maskAttr)) {
@@ -82,6 +84,9 @@ angular.module('ui.mask', [])
             if (value === '' && controller.$error.required !== undefined) {
               controller.$setValidity('required', false);
             }
+            // Transform the value to be the viewValue
+            if (useViewValue)
+                value = value.length ? maskValue(value) : '';
             return isValid ? value : undefined;
           }
 
@@ -109,6 +114,9 @@ angular.module('ui.mask', [])
           }
 
           iAttrs.$observe('uiMask', initialize);
+          iAttrs.$observe('uiMaskUseViewvalue', function (useVVal) {
+              useViewValue = useVVal == 'true';
+          });
           iAttrs.$observe('placeholder', initPlaceholder);
           var modelViewValue = false;
           iAttrs.$observe('modelViewValue', function(val) {

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -81,9 +81,7 @@ angular.module('ui.mask', [])
             // to be out-of-sync with what the controller's $viewValue is set to.
             controller.$viewValue = value.length ? maskValue(value) : '';
             controller.$setValidity('mask', isValid);
-            if (value === '' && controller.$error.required !== undefined) {
-              controller.$setValidity('required', false);
-            }
+            
             // Transform the value to be the viewValue
             if (useViewValue)
                 value = value.length ? maskValue(value) : '';


### PR DESCRIPTION
The mask cannot return it's view value, only the raw value.

In some cases, we would like the view value to be return.

This way we can simply just do: 
```
<input type="text" name="CellPhone" ng-model="field.Value"  
                             ui-mask="99999999" ui-mask-use-viewvalue="true" >
```

Also removed the responsibility of setting the required validation of ngModel. // No longer valid