### PR TITLE
extensible keymap in ui.keypress

### DIFF
--- a/modules/keypress/keypress.js
+++ b/modules/keypress/keypress.js
@@ -1,8 +1,9 @@
 'use strict';
 
 angular.module('ui.keypress',[]).
-factory('keypressHelper', ['$parse', function keypress($parse){
-  var keysByCode = {
+provider('keysByCode', function () {
+  var keysByCode = this;
+  keysByCode.keymap = {
     8: 'backspace',
     9: 'tab',
     13: 'enter',
@@ -19,7 +20,11 @@ factory('keypressHelper', ['$parse', function keypress($parse){
     45: 'insert',
     46: 'delete'
   };
-
+  keysByCode.$get = function () {
+    return keysByCode.keymap;
+  };
+}).
+factory('keypressHelper', ['$parse', 'keysByCode', function keypress($parse, keysByCode){
   var capitaliseFirstLetter = function (string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
   };

--- a/modules/keypress/test/keydownSpec.js
+++ b/modules/keypress/test/keydownSpec.js
@@ -21,6 +21,9 @@ describe('uiKeydown', function () {
   };
 
   beforeEach(module('ui.keypress'));
+  beforeEach(module(function (keysByCodeProvider) {
+    keysByCodeProvider.keymap[65] = 'a';
+  }));
   beforeEach(inject(function (_$rootScope_, _$compile_) {
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
@@ -72,5 +75,12 @@ describe('uiKeydown', function () {
 
     element.trigger(createKeyEvent(13));
     expect($scope.event2.keyCode).toBe(13);
+  });
+
+  it('should allow to configure custom key aliases', function () {
+    var element = createElement({'a': 'cb($event)'});
+
+    element.trigger(createKeyEvent(65));
+    expect($scope.event1.keyCode).toBe(65);
   });
 });

--- a/modules/keypress/test/keypressSpec.js
+++ b/modules/keypress/test/keypressSpec.js
@@ -21,6 +21,9 @@ describe('uiKeypress', function () {
   };
 
   beforeEach(module('ui.keypress'));
+  beforeEach(module(function (keysByCodeProvider) {
+    keysByCodeProvider.keymap[65] = 'a';
+  }));
   beforeEach(inject(function (_$rootScope_, _$compile_) {
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
@@ -72,5 +75,12 @@ describe('uiKeypress', function () {
 
     element.trigger(createKeyEvent(13));
     expect($scope.event2.keyCode).toBe(13);
+  });
+
+  it('should allow to configure custom key aliases', function () {
+    var element = createElement({'a': 'cb($event)'});
+
+    element.trigger(createKeyEvent(65));
+    expect($scope.event1.keyCode).toBe(65);
   });
 });

--- a/modules/keypress/test/keyupSpec.js
+++ b/modules/keypress/test/keyupSpec.js
@@ -21,6 +21,9 @@ describe('uiKeyup', function () {
   };
 
   beforeEach(module('ui.keypress'));
+  beforeEach(module(function (keysByCodeProvider) {
+    keysByCodeProvider.keymap[65] = 'a';
+  }));
   beforeEach(inject(function (_$rootScope_, _$compile_) {
     $compile = _$compile_;
     $scope = _$rootScope_.$new();
@@ -72,5 +75,12 @@ describe('uiKeyup', function () {
 
     element.trigger(createKeyEvent(13));
     expect($scope.event2.keyCode).toBe(13);
+  });
+
+  it('should allow to configure custom key aliases', function () {
+    var element = createElement({'a': 'cb($event)'});
+
+    element.trigger(createKeyEvent(65));
+    expect($scope.event1.keyCode).toBe(65);
   });
 });


### PR DESCRIPTION
I suggest turning `keysByCode` object into a provider to enable adding new named key codes or to change the name if one wish, 
