### PR TITLE
improve code reuse of keypressHelper

### DIFF
--- a/modules/keypress/keypress.js
+++ b/modules/keypress/keypress.js
@@ -24,9 +24,9 @@ factory('keypressHelper', ['$parse', function keypress($parse){
     return string.charAt(0).toUpperCase() + string.slice(1);
   };
 
-  return function(mode, scope, elm, attrs) {
-    var params, combinations = [];
-    params = scope.$eval(attrs['ui'+capitaliseFirstLetter(mode)]);
+  return function(mode, scope, elm, attrs, params) {
+    var combinations = [];
+    params = params || scope.$eval(attrs['ui'+capitaliseFirstLetter(mode)]);
 
     // Prepare combinations for simple checking
     angular.forEach(params, function (v, k) {

--- a/modules/keypress/test/keydownSpec.js
+++ b/modules/keypress/test/keydownSpec.js
@@ -73,4 +73,16 @@ describe('uiKeydown', function () {
     element.trigger(createKeyEvent(13));
     expect($scope.event2.keyCode).toBe(13);
   });
+
+  it('should allow to bind keys via API', inject(function (keypressHelper) {
+
+    var element = $compile('<span></span>')($scope);
+
+    keypressHelper('keydown', $scope, element, null,  {
+      enter: 'cb($event)'
+    });
+
+    element.trigger(createKeyEvent(13));
+    expect($scope.event1.keyCode).toBe(13);
+  }));
 });

--- a/modules/keypress/test/keypressSpec.js
+++ b/modules/keypress/test/keypressSpec.js
@@ -73,4 +73,16 @@ describe('uiKeypress', function () {
     element.trigger(createKeyEvent(13));
     expect($scope.event2.keyCode).toBe(13);
   });
+
+  it('should allow to bind keys via API', inject(function (keypressHelper) {
+
+    var element = $compile('<span></span>')($scope);
+
+    keypressHelper('keypress', $scope, element, null,  {
+      enter: 'cb($event)'
+    });
+
+    element.trigger(createKeyEvent(13));
+    expect($scope.event1.keyCode).toBe(13);
+  }));
 });

--- a/modules/keypress/test/keyupSpec.js
+++ b/modules/keypress/test/keyupSpec.js
@@ -73,4 +73,16 @@ describe('uiKeyup', function () {
     element.trigger(createKeyEvent(13));
     expect($scope.event2.keyCode).toBe(13);
   });
+
+  it('should allow to bind keys via API', inject(function (keypressHelper) {
+
+    var element = $compile('<span></span>')($scope);
+
+    keypressHelper('keyup', $scope, element, null,  {
+      enter: 'cb($event)'
+    });
+
+    element.trigger(createKeyEvent(13));
+    expect($scope.event1.keyCode).toBe(13);
+  }));
 });


### PR DESCRIPTION
I suggest allowing the usage of `keypressHelper` as an injectable service without the necessity to provide params as attribute value in a template.

Background:
I'm building a keyboard interface with many shortcuts and I intend to use `ui.keypress` method of denoting the combinations but it's not yet possible to use the helper in other directives in other way than providing the   mapping as JSON.
