### PR TITLE
Fixes angular-ui/ui-utils#204 - improve error message and readme notes about viewport height.

### DIFF
--- a/modules/scroll/README.md
+++ b/modules/scroll/README.md
@@ -24,9 +24,9 @@ the datasource. The datasource name is specified in the scroll_expression.
 The viewport is an element representing the space where the items from the collection are to be shown. Unless specified explicitly with the
 ngScrollViewport directive (see below), browser window will be used as viewport.
 
-**Important:** The viewport height has to be constrained because the directive will stop asking the datasource for more elements only when it has enough
-to fill out the viewport. If the height of the viewport is not constrained (style="height:auto") this will never happen and the directive will
-try to pull the entire content of the datasource.
+**Important: viewport height must be constrained.** The directive will stop asking the datasource for more elements only when it has enough
+to fill out the viewport. If the height of the viewport is not constrained (style="height:auto") this may throw an Error, or it could
+pull the entire content of the datasource.
 
 ### Dependencies
 

--- a/modules/scroll/ui-scroll.js
+++ b/modules/scroll/ui-scroll.js
@@ -52,6 +52,10 @@ angular.module('ui.scroll', []).directive('ngScrollViewport', [
 							return viewport.height() * Math.max(0.1, +$attr.padding || 0.1);
 						};
 						scrollHeight = function(elem) {
+							console.log(elem[0].scrollHeight, elem[0].document);
+							if( !elem[0].scrollHeight && !elem[0].document ) {
+								throw new Error('Could not determine scrollHeight of your viewport; make sure it has a constrained height (not height:auto)');
+							}
 							return elem[0].scrollHeight || elem[0].document.documentElement.scrollHeight;
 						};
 						adapter = null;


### PR DESCRIPTION
A quick change to improve the error message for missing height elements and some clarification to the README.

So I'm part of the solution and not just an annoying noob. Bin this if it doesn't look useful or amend as you see fit.

![image](https://f.cloud.github.com/assets/959972/2485270/d90a740a-b116-11e3-8b9d-05573b749572.png)
