### PR TITLE
updated highlight code to properly escape regex characters. closes #195

### DIFF
--- a/modules/highlight/highlight.js
+++ b/modules/highlight/highlight.js
@@ -14,7 +14,8 @@ angular.module('ui.highlight',[]).filter('highlight', function () {
       if (caseSensitive) {
         return text.split(search).join('<span class="ui-match">' + search + '</span>');
       } else {
-        return text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>');
+        var escapedSearch = search.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
+        return text.replace(new RegExp(escapedSearch, 'gi'), '<span class="ui-match">$&</span>');
       }
     } else {
       return text;

--- a/modules/highlight/test/highlightSpec.js
+++ b/modules/highlight/test/highlightSpec.js
@@ -2,6 +2,7 @@ describe('highlight', function () {
   'use strict';
 
   var highlightFilter, testPhrase = 'Prefix Highlight Suffix';
+  var regexTestPhrase = 'Prefix (.*+?^=!:${}()|[]/) Suffix';
 
   beforeEach(module('ui.highlight'));
   beforeEach(inject(function ($filter) {
@@ -23,6 +24,9 @@ describe('highlight', function () {
     it('should work correctly for number text', function () {
       expect(highlightFilter(3210123, '0')).toEqual('321<span class="ui-match">0</span>123');
     });
+    it('should work correctly when regex special characters are present', function (){
+      expect(highlightFilter(regexTestPhrase,'(.*+?^=!:${}()|[]/)')).toEqual('Prefix <span class="ui-match">(.*+?^=!:${}()|[]/)</span> Suffix');
+    });
   });
   describe('case sensitive', function () {
     it('should highlight a matching phrase', function () {
@@ -39,6 +43,9 @@ describe('highlight', function () {
     });
     it('should work correctly for number text', function () {
       expect(highlightFilter(3210123, '0', true)).toEqual('321<span class="ui-match">0</span>123');
+    });
+    it('should work correctly when regex special characters are present', function (){
+      expect(highlightFilter(regexTestPhrase,'(.*+?^=!:${}()|[]/)')).toEqual('Prefix <span class="ui-match">(.*+?^=!:${}()|[]/)</span> Suffix');
     });
     it('should not highlight a phrase with different letter-casing', function () {
       expect(highlightFilter(testPhrase, 'highlight', true)).toEqual(testPhrase);


### PR DESCRIPTION
This commit escapes regex characters in search text, this was noted in issue #195
