### PR TITLE
Update event.js for IE8 compatability

### DIFF
--- a/modules/event/event.js
+++ b/modules/event/event.js
@@ -19,7 +19,7 @@ angular.module('ui.event',[]).directive('uiEvent', ['$parse',
         elm.bind(eventName, function (evt) {
           var params = Array.prototype.slice.call(arguments);
           //Take out first paramater (event object);
-          params = params.splice(1);
+          params = params.splice(1, params.length-1);
           fn($scope, {$event: evt, $params: params});
           if (!$scope.$$phase) {
             $scope.$apply();


### PR DESCRIPTION
IE8 does not support the use of the splice() function with one parameter thus we have to use splice(1, params.length-1). This returns all the objects in params except the first one.
