### PR TITLE
fixes IE bug: on TAB text should be highlighted

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -425,6 +425,8 @@ angular.module('ui.mask', [])
               caretPos++;
             }
             oldCaretPosition = caretPos;
+            //char position fix when mask does not starts with first character such as phone for example (___) ___-___
+            if (valueMasked[0] !== '_') caretPos++; 
             setCaretPosition(this, caretPos);
           }
 


### PR DESCRIPTION
Only on IE - input text with mask does not get highlighted when receives focus on TAB.
This line fixes that.
