### PR TITLE
Fix IE Tab issue, and cursor issue when typing after tab selection.

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -323,6 +323,9 @@ angular.module('ui.mask', [])
             var eventWhich = e.which,
               eventType = e.type;
 
+            // When tabbed into the input - select the text
+            if (eventWhich === 9) { this.select(); return; }
+
             // Prevent shift and ctrl from mucking with old values
             if (eventWhich === 16 || eventWhich === 91) { return;}
 
@@ -422,6 +425,10 @@ angular.module('ui.mask', [])
               caretPos++;
             }
             oldCaretPosition = caretPos;
+
+            //Fix the cursor position if the mask contain masking character on 1st field (for example phone "(___)___-____")
+            if (valUnmasked.length === 1 && valOld.indexOf('_') !== 0) { caretPos = 2; }
+
             setCaretPosition(this, caretPos);
           }
 


### PR DESCRIPTION
Code fixes 2 (related) issues:
1) Only on IE - input text with mask does not get highlighted when receives focus on TAB.
![Image](https://raw.githubusercontent.com/miticv/ShareImages/master/ui-utils/mask/Tab.png)

also notice position of the cursor above - it is not positioned to the correct position. 

2) (Issue in any browser not just IE) If mask does not starts with first character such as phone for example (___) ___-___
then when you tab into the input field and start typing - your character will be 1 off:

![Image](https://raw.githubusercontent.com/miticv/ShareImages/master/ui-utils/mask/TabCursor.png)
