### PR TITLE
ui-mask: Fix IE Tab issue, and cursor issue when typing after tab selection.

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -427,7 +427,7 @@ angular.module('ui.mask', [])
             oldCaretPosition = caretPos;
 
             //Fix the cursor position if the mask contain masking character on 1st field (for example phone "(___)___-____")
-            if (valUnmasked.length === 1 && valOld.indexOf('_') !== 0) { caretPos = 2; }
+            if (valUnmasked.length === 1 && maskPlaceholder.indexOf('_') !== 0 && eventWhich !== 8) { if (eventWhich === 46) {caretPos = 1; } else {caretPos = 2; }
 
             setCaretPosition(this, caretPos);
           }


### PR DESCRIPTION
Code fixes 2 (related) issues:
1) Only on IE:
Input text with mask does not get highlighted when receives focus on TAB.
![Image](https://raw.githubusercontent.com/miticv/ShareImages/master/ui-utils/mask/Tab.png)

also notice position of the cursor above - it is not positioned to the correct position. 

2) In any browser (not just IE):
If mask does not starts with first character such as phone for example (___) ___-___
then when you tab into the input field and start typing - your character will be 1 off:

![Image](https://raw.githubusercontent.com/miticv/ShareImages/master/ui-utils/mask/TabCursor.png)
