### PR TITLE
fix(scrollfix): improve speed by preventing evaluating on each onScroll ...

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -5,10 +5,11 @@
  * @param [offset] {int} optional Y-offset to override the detected offset.
  *   Takes 300 (absolute) or -300 or +300 (relative to detected)
  */
-angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function ($window) {
+angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', '$timeout', function ($window, $timeout) {
   return {
     require: '^?uiScrollfixTarget',
     link: function (scope, elm, attrs, uiScrollfixTarget) {
+      var promise = null;
       var top = elm[0].offsetTop,
           $target = uiScrollfixTarget && uiScrollfixTarget.$element || angular.element($window);
 
@@ -24,19 +25,22 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
       }
 
       function onScroll() {
-        // if pageYOffset is defined use it, otherwise use other crap for IE
-        var offset;
-        if (angular.isDefined($window.pageYOffset)) {
-          offset = $window.pageYOffset;
-        } else {
-          var iebody = (document.compatMode && document.compatMode !== 'BackCompat') ? document.documentElement : document.body;
-          offset = iebody.scrollTop;
-        }
-        if (!elm.hasClass('ui-scrollfix') && offset > attrs.uiScrollfix) {
-          elm.addClass('ui-scrollfix');
-        } else if (elm.hasClass('ui-scrollfix') && offset < attrs.uiScrollfix) {
-          elm.removeClass('ui-scrollfix');
-        }
+        $timeout.cancel(promise);
+        promise = $timeout(function() {
+            // if pageYOffset is defined use it, otherwise use other crap for IE
+            var offset;
+            if (angular.isDefined($window.pageYOffset)) {
+              offset = $window.pageYOffset;
+            } else {
+              var iebody = (document.compatMode && document.compatMode !== 'BackCompat') ? document.documentElement : document.body;
+              offset = iebody.scrollTop;
+            }
+            if (!elm.hasClass('ui-scrollfix') && offset > attrs.uiScrollfix) {
+              elm.addClass('ui-scrollfix');
+            } else if (elm.hasClass('ui-scrollfix') && offset < attrs.uiScrollfix) {
+              elm.removeClass('ui-scrollfix');
+            }
+        }, 300, false);
       }
 
       $target.on('scroll', onScroll);

--- a/modules/scrollfix/test/scrollfixSpec.js
+++ b/modules/scrollfix/test/scrollfixSpec.js
@@ -2,12 +2,13 @@
 describe('uiScrollfix', function () {
   'use strict';
 
-  var scope, $compile, $window;
+  var scope, $compile, $window, $timeout;
   beforeEach(module('ui.scrollfix'));
-  beforeEach(inject(function (_$rootScope_, _$compile_, _$window_) {
+  beforeEach(inject(function (_$rootScope_, _$compile_, _$window_, _$timeout_) {
     scope = _$rootScope_.$new();
     $compile = _$compile_;
     $window = _$window_;
+    $timeout = _$timeout_;
   }));
 
   describe('compiling this directive', function () {
@@ -39,17 +40,20 @@ describe('uiScrollfix', function () {
     it('should add the ui-scrollfix class if the offset is greater than specified', function () {
       var element = $compile('<div ui-scrollfix="-100"></div>')(scope);
       angular.element($window).trigger('scroll');
+      $timeout.flush();
       expect(element.hasClass('ui-scrollfix')).toBe(true);
     });
     it('should remove the ui-scrollfix class if the offset is less than specified (using absolute coord)', function () {
       var element = $compile('<div ui-scrollfix="100" class="ui-scrollfix"></div>')(scope);
       angular.element($window).trigger('scroll');
+      $timeout.flush();
       expect(element.hasClass('ui-scrollfix')).toBe(false);
 
     });
     it('should remove the ui-scrollfix class if the offset is less than specified (using relative coord)', function () {
       var element = $compile('<div ui-scrollfix="+100" class="ui-scrollfix"></div>')(scope);
       angular.element($window).trigger('scroll');
+      $timeout.flush();
       expect(element.hasClass('ui-scrollfix')).toBe(false);
     });
   });


### PR DESCRIPTION
Improve speed by preventing evaluating on each onScroll event using $timeout. Classes are added or removed only once during one scroll, instead for each line.
