### PR TITLE
bug(ui.mask): change required check in parser

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -79,7 +79,7 @@ angular.module('ui.mask', [])
             // to be out-of-sync with what the controller's $viewValue is set to.
             controller.$viewValue = value.length ? maskValue(value) : '';
             controller.$setValidity('mask', isValid);
-            if (value === '' && controller.$error.required !== undefined) {
+            if (value === '' && iAttrs.required) {
               controller.$setValidity('required', false);
             }
             return isValid ? value : undefined;

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -113,6 +113,39 @@ describe("uiMask", function () {
       input.triggerHandler("input");
       expect(scope.x).toBe("");
     });
+
+    it("should not setValidity on required to false on a control that isn't required", function() {
+      var input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}'>");
+      scope.$apply("x = ''");
+      scope.$apply("mask = '(A) * 9'");
+      scope.$apply("required = true");
+      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      input.triggerHandler("input");
+      expect(scope.x).toBe("");
+      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+
+      input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}' required>");
+      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      input.triggerHandler("input");
+      expect(input.data("$ngModelController").$error.required).toBe(true);
+      input.val("abc123").triggerHandler("input");
+      expect(scope.x).toBe("ab1");
+      expect(input.data("$ngModelController").$error.required).toBe(false);
+
+      input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}' ng-required='required'>");
+      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      input.triggerHandler("input");
+      expect(input.data("$ngModelController").$error.required).toBe(true);
+      scope.$apply("required = false");
+      expect(input.data("$ngModelController").$error.required).toBe(false);
+      input.triggerHandler("input");
+      expect(input.data("$ngModelController").$error.required).toBe(false);
+      input.triggerHandler("focus");
+      input.triggerHandler("blur");
+      expect(input.data("$ngModelController").$error.required).toBe(false);
+      input.val("").triggerHandler("input");
+      expect(input.data("$ngModelController").$error.required).toBe(false);
+    });
   });
 
   describe("changes from the model", function () {


### PR DESCRIPTION
This bug occurs when a control is meant to be masked but not required. You can reproduce the error [here](http://plnkr.co/edit/Szgygfocqh4UzJPhijtA?p=preview).

Before the parser checked to see if the controller$error.required was defined. If so, it would set the required validity to false. This doesn't work if ng-required is used, because the control could have been required at one point and is no longer required. Instead this checks if the elements attribute object contains a required property and if said property is true.

BREAKING CHANGE: if you rely on ui-mask to invalidate an empty viewValue this will no longer work. Please use the required attribute or ng-required directive to specify whether the input is required.
