### PR TITLE
Mask formatter collision

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -57,29 +57,19 @@ angular.module('ui.mask', [])
             }
           }
 
-        function formatter(fromModelValue){
-          // Need to check if there are other formatters, so we don't conflict with them
-          var customValueCheck = false;
-          angular.forEach(controller.$formatters,function(i){
-            if (i !== formatter) {
-              customValueCheck = true;
+          function formatter(fromModelValue){
+            if (!maskProcessed) {
+              return fromModelValue;
             }
-          });
-
-          if (!maskProcessed) {
-            return fromModelValue;
+            value = unmaskValue(fromModelValue || '');
+            isValid = validateValue(value);
+            controller.$setValidity('mask', isValid);
+            if (iAttrs.uiMaskSupressFormatter != null) {
+              return isValid && value.length ? fromModelValue : undefined;
+            } else {
+              return isValid && value.length ? maskValue(value) : undefined;
+            }
           }
-          value = unmaskValue(fromModelValue || '');
-          isValid = validateValue(value);
-          controller.$setValidity('mask', isValid);
-
-          if (customValueCheck) {
-            maskValue(value); // Mask the value, but don't return its result
-            return isValid && value.length ? fromModelValue : undefined;
-          } else {
-            return isValid && value.length ? maskValue(value) : undefined;
-          }
-        }
 
           function parser(fromViewValue){
             if (!maskProcessed) {
@@ -96,7 +86,12 @@ angular.module('ui.mask', [])
             if (value === '' && controller.$error.required !== undefined) {
               controller.$setValidity('required', false);
             }
-            return isValid ? value : undefined;
+
+            if (iAttrs.uiMaskSupressParser != null) {
+              return isValid ? fromViewValue : undefined;
+            } else {
+              return isValid ? value : undefined;
+            }
           }
 
           var linkOptions = {};

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -64,7 +64,7 @@ angular.module('ui.mask', [])
             value = unmaskValue(fromModelValue || '');
             isValid = validateValue(value);
             controller.$setValidity('mask', isValid);
-            if (iAttrs.uiMaskSupressFormatter != null) {
+            if (iAttrs.uiMaskSuppressFormatter != null) {
               return isValid && value.length ? fromModelValue : undefined;
             } else {
               return isValid && value.length ? maskValue(value) : undefined;
@@ -87,7 +87,7 @@ angular.module('ui.mask', [])
               controller.$setValidity('required', false);
             }
 
-            if (iAttrs.uiMaskSupressParser != null) {
+            if (iAttrs.uiMaskSuppressParser != null) {
               return isValid ? fromViewValue : undefined;
             } else {
               return isValid ? value : undefined;

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -57,15 +57,29 @@ angular.module('ui.mask', [])
             }
           }
 
-          function formatter(fromModelValue){
+        function formatter(fromModelValue){
+            // Need to check if there are other formatters, so we don't conflict with them
+            var customValueCheck = false;
+            angular.forEach(controller.$formatters,function(i){
+                if (i !== formatter) {
+                    customValueCheck = true;
+                }
+            });
+
             if (!maskProcessed) {
-              return fromModelValue;
+                return fromModelValue;
             }
             value = unmaskValue(fromModelValue || '');
             isValid = validateValue(value);
             controller.$setValidity('mask', isValid);
-            return isValid && value.length ? maskValue(value) : undefined;
-          }
+
+            if (customValueCheck) {
+                maskValue(value); // Mask the value, but don't return its result
+                return isValid && value.length ? fromModelValue : undefined;
+            } else {
+                return isValid && value.length ? maskValue(value) : undefined;
+            }
+        }
 
           function parser(fromViewValue){
             if (!maskProcessed) {

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -58,27 +58,27 @@ angular.module('ui.mask', [])
           }
 
         function formatter(fromModelValue){
-            // Need to check if there are other formatters, so we don't conflict with them
-            var customValueCheck = false;
-            angular.forEach(controller.$formatters,function(i){
-                if (i !== formatter) {
-                    customValueCheck = true;
-                }
-            });
-
-            if (!maskProcessed) {
-                return fromModelValue;
+          // Need to check if there are other formatters, so we don't conflict with them
+          var customValueCheck = false;
+          angular.forEach(controller.$formatters,function(i){
+            if (i !== formatter) {
+              customValueCheck = true;
             }
-            value = unmaskValue(fromModelValue || '');
-            isValid = validateValue(value);
-            controller.$setValidity('mask', isValid);
+          });
 
-            if (customValueCheck) {
-                maskValue(value); // Mask the value, but don't return its result
-                return isValid && value.length ? fromModelValue : undefined;
-            } else {
-                return isValid && value.length ? maskValue(value) : undefined;
-            }
+          if (!maskProcessed) {
+            return fromModelValue;
+          }
+          value = unmaskValue(fromModelValue || '');
+          isValid = validateValue(value);
+          controller.$setValidity('mask', isValid);
+
+          if (customValueCheck) {
+            maskValue(value); // Mask the value, but don't return its result
+            return isValid && value.length ? fromModelValue : undefined;
+          } else {
+            return isValid && value.length ? maskValue(value) : undefined;
+          }
         }
 
           function parser(fromViewValue){


### PR DESCRIPTION
This is an implementation to deal with https://github.com/angular-ui/ui-utils/issues/139. Essentially the problem is different `formatters` conflicting with eachother. There are many ways to _solve_ this problem, the one implemented in this pull request checks if a `formatter` exists apart from the one used by `ui-mask`, if more formatters exist, then the formatter will return the original value, instead of the one created by `maskValue(value)`

This means that if you only use `ui-mask` with no other formatters, it works as intended, but if you use `ui-mask` with other formatters, it won't return the remasked value.

Test cases have yet to be written as I am waiting on feedback if this is the ideal way to solve this problem, however this implementation passes all the current tests
