### PR TITLE
Rename residual ng-scroll -> ui-scroll instances

### DIFF
--- a/modules/scroll/README.md
+++ b/modules/scroll/README.md
@@ -7,22 +7,22 @@ they are still a part of the page and still consume resources. As the user scrol
 This becomes a real problem if the html representing a row has event handlers and/or angular watchers attached. A web app of an average
 complexity can easily introduce 20 watchers per row. Which for a list of 100 rows gives you total of 2000 watchers and a sluggish app.
 
-ngScroll directive
+uiScroll directive
 -------------------
 
 [![Build Status](https://travis-ci.org/Hill30/NGScroller.png?branch=master)](https://travis-ci.org/Hill30/NGScroller)
 
-**ngScroll** directive solves this problem by dynamically destroying elements as they become invisible and recreating
+**uiScroll** directive solves this problem by dynamically destroying elements as they become invisible and recreating
 them if they become visible again.
 
 ###Description
 
-The ngScroll directive is similar to the ngRepeat. Like the ngRepeat, ngScroll directive instantiates a template once per item from a collection.
+The uiScroll directive is similar to the ngRepeat. Like the ngRepeat, uiScroll directive instantiates a template once per item from a collection.
 Each template instance gets its own scope, where the given loop variable is set to the current collection item. The collection content is provided by
 the datasource. The datasource name is specified in the scroll_expression.
 
 The viewport is an element representing the space where the items from the collection are to be shown. Unless specified explicitly with the
-ngScrollViewport directive (see below), browser window will be used as viewport.
+uiScrollViewport directive (see below), browser window will be used as viewport.
 
 **Important: viewport height must be constrained.** The directive will stop asking the datasource for more elements only when it has enough
  to fill out the viewport. If the height of the viewport is not constrained (style="height:auto")  it will pull the entire content of the datasource
@@ -44,13 +44,13 @@ File ui-scroll-jqlite.coffee houses implementations of the above methods and als
 'ui.scroll.jqlite' and this name should also be included in the dependency list of the main module. The implementation currently supports missing methods
 only as necessary for the directive. It is tested on IE8 and up as well as on the Chrome 28 and Firefox 20.
 
-This module is only necessary if you plan to use ng-scroll without jQuery. If jQuery implementation is present it will not override them.
-If you plan to use ng-scroll over jQuery feel free to skip ui-scroll-jqlite.
+This module is only necessary if you plan to use ui-scroll without jQuery. If jQuery implementation is present it will not override them.
+If you plan to use ui-scroll over jQuery feel free to skip ui-scroll-jqlite.
 
 ###Usage
 
 ```html
-<ANY ng-scroll="{scroll_expression}" buffer-size="value" padding="value">
+<ANY ui-scroll="{scroll_expression}" buffer-size="value" padding="value">
       ...
 </ANY>
 ```
@@ -65,7 +65,7 @@ dl as a repeated tag is not supported.
 * This directive executes at priority level 1000
 
 ###Parameters
-* **ngScroll – {scroll_expression}** – The expression indicating how to enumerate a collection. Only one format is currently supported:
+* **uiScroll – {scroll_expression}** – The expression indicating how to enumerate a collection. Only one format is currently supported:
     * **variable in datasource** – where variable is the user defined loop variable and datasource is the name of the data source service to enumerate.
 * **buffer-size - value**, optional - number of items requested from the datasource in a single request. The default is 10 and the minimal value is 3
 * **padding - value**, optional - extra height added to the visible area for the purpose of determining when the items should be created/destroyed.
@@ -76,7 +76,7 @@ The value is relative to the visible height of the area, the default is 0.5 and 
 * **top-visible-scope - name**, optional - if provided a reference to the scope created for the item currently in the topmost visible position will be placed in the member with the said name on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope
 
 ###Data Source 
-Data source is an object to be used by the ngScroll directive to access the data. 
+Data source is an object to be used by the uiScroll directive to access the data. 
 
 The directive will locate the object using the provided data source name. It will first look for a property with the given name on its $scope.
 If none found it will try to get an angular service with the provided name.
@@ -116,17 +116,17 @@ exactly `count` elements unless it hit eof/bof
     this is an optional method. If supplied the scroller will $watch its value and will refresh the content if the value has changed
 
 
-ngScrollViewport directive
+uiScrollViewport directive
 -------------------
 ###Description
 
-The ngScrollViewport directive marks a particular element as viewport for the ngScroll directive. If no parent of the ngScroll directive is
-marked with ngScrollViewport directive, the browser window object will be used as viewport
+The uiScrollViewport directive marks a particular element as viewport for the uiScroll directive. If no parent of the uiScroll directive is
+marked with uiScrollViewport directive, the browser window object will be used as viewport
 
 ###Usage
 
 ```html
-<ANY ng-scroll-viewport>
+<ANY ui-scroll-viewport>
       ...
 </ANY>
 ```
@@ -134,7 +134,7 @@ marked with ngScrollViewport directive, the browser window object will be used a
 
 ###Examples
 
-Currently examples consist of a sample datasource service (called 'datasource' see [application.coffee] (https://github.com/Hill30/NGScroller/blob/master/src/scripts/application.coffee)) and several pages with different ways the ng-scroll can be used.
+Currently examples consist of a sample datasource service (called 'datasource' see [application.coffee] (https://github.com/Hill30/NGScroller/blob/master/src/scripts/application.coffee)) and several pages with different ways the ui-scroll can be used.
 I intentionally broke every rule of proper html/css structure (i.e. embedded styles). This is done to keep the html as bare bones as possible and leave
 it to you to do it properly - whatever properly means in your book.
 
@@ -158,4 +158,4 @@ Introduced `is-loading` and `top-visible-*` attributes. Streamlined and added a 
 
 ####v0.0.*
 
-Initial commit including ngScroll, ngScrollViewPort directives and usage examples
+Initial commit including uiScroll, uiScrollViewPort directives and usage examples

--- a/modules/scroll/scroll.js
+++ b/modules/scroll/scroll.js
@@ -35,7 +35,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
           log = console.debug || console.log;
           match = $attr.uiScroll.match(/^\s*(\w+)\s+in\s+(\w+)\s*$/);
           if (!match) {
-            throw new Error('Expected ngScroll in form of \'_item_ in _datasource_\' but got \'' + $attr.uiScroll + '\'');
+            throw new Error('Expected uiScroll in form of \'_item_ in _datasource_\' but got \'' + $attr.uiScroll + '\'');
           }
           itemName = match[1];
           datasourceName = match[2];
@@ -62,7 +62,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
             var bottomPadding, createPadding, padding, repeaterType, topPadding, viewport;
             repeaterType = template[0].localName;
             if (repeaterType === 'dl') {
-              throw new Error('ng-scroll directive does not support <' + template[0].localName + '> as a repeating tag: ' + template[0].outerHTML);
+              throw new Error('ui-scroll directive does not support <' + template[0].localName + '> as a repeating tag: ' + template[0].outerHTML);
             }
             if (repeaterType !== 'li' && repeaterType !== 'tr') {
               repeaterType = 'div';


### PR DESCRIPTION
ng-scroll was recently renamed to ui-scroll, but there were places where the
rename was missed (crucially, the readme!).
