### PR TITLE
scroll v.1.0.0

### DIFF
--- a/modules/scroll/README.md
+++ b/modules/scroll/README.md
@@ -134,7 +134,8 @@ marked with uiScrollViewport directive, the browser window object will be used a
 
 ###Examples
 
-Currently examples consist of a sample datasource service (called 'datasource' see [application.coffee] (https://github.com/Hill30/NGScroller/blob/master/src/scripts/application.coffee)) and several pages with different ways the ui-scroll can be used.
+Examples ([look here](https://github.com/Hill30/NGScroller/tree/master/src/examples)) consist of several pages (.html files) showing various ways to use the ui-scroll directive. Each page relays on its own datasource service (called `datasource`) defined in the coffescript file with the same name and .coffee extension.
+
 I intentionally broke every rule of proper html/css structure (i.e. embedded styles). This is done to keep the html as bare bones as possible and leave
 it to you to do it properly - whatever properly means in your book.
 
@@ -152,10 +153,20 @@ Do not ask me why this woodoo is necessary, but as of Chrome version 30 it is ju
 
 ###History
 
+####v1.0.0
+
+* Renamed ng-scroll to ui-scroll.
+* Reduced server requests by eof and bof recalculation.
+* Support for inline-block/floated elements.
+* Reduced flickering via new blocks rendering optimization.
+* Prevented unwanted scroll bubbling.
+* Fixed race-condition and others minor bugs.
+* Added more usage examples (such as cache within datasource implementation).
+
 ####v0.1.*
 
-Introduced `is-loading` and `top-visible-*` attributes. Streamlined and added a few more usage examples
+Introduced `is-loading` and `top-visible-*` attributes. Streamlined and added a few more usage examples.
 
 ####v0.0.*
 
-Initial commit including uiScroll, uiScrollViewPort directives and usage examples
+Initial commit including uiScroll, uiScrollViewPort directives and usage examples.

--- a/modules/scroll/scroll-jqlite.js
+++ b/modules/scroll/scroll-jqlite.js
@@ -168,7 +168,7 @@ angular.module('ui.scroll.jqlite', ['ui.scroll']).service('jqLiteExtras', [
             return getWidthHeight(this[0], 'height', option ? 'outerfull' : 'outer');
           },
           /*
-          NGScroller no longer relies on jQuery method offset. The jQLite implementation of the method
+          UIScroller no longer relies on jQuery method offset. The jQLite implementation of the method
           is kept here just for the reference. Also the offset setter method was never implemented
           */
 

--- a/modules/scroll/scroll.js
+++ b/modules/scroll/scroll.js
@@ -31,7 +31,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
       terminal: true,
       compile: function(elementTemplate, attr, linker) {
         return function($scope, element, $attr, controllers) {
-          var adapter, adjustBuffer, adjustRowHeight, bof, bottomVisiblePos, buffer, bufferPadding, bufferSize, clipBottom, clipTop, datasource, datasourceName, enqueueFetch, eof, eventListener, fetch, finalize, first, insert, isDatasource, isLoading, itemName, loading, log, match, next, pending, reload, removeFromBuffer, resizeHandler, ridActual, scrollHandler, scrollHeight, shouldLoadBottom, shouldLoadTop, tempScope, topVisible, topVisibleElement, topVisibleItem, topVisiblePos, topVisibleScope, viewport, viewportScope;
+          var adapter, adjustBuffer, adjustRowHeight, bof, bottomVisiblePos, buffer, bufferPadding, bufferSize, clipBottom, clipTop, datasource, datasourceName, doAdjustment, enqueueFetch, eof, eventListener, fetch, finalize, first, hideElementBeforeAppend, insert, isDatasource, isLoading, itemName, loading, log, match, next, pending, reload, removeFromBuffer, resizeHandler, ridActual, scrollHandler, scrollHeight, shouldLoadBottom, shouldLoadTop, showElementAfterRender, tempScope, topVisible, topVisibleElement, topVisibleItem, topVisiblePos, topVisibleScope, viewport, viewportScope, wheelHandler;
           log = console.debug || console.log;
           match = $attr.uiScroll.match(/^\s*(\w+)\s+in\s+(\w+)\s*$/);
           if (!match) {
@@ -51,7 +51,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
           }
           bufferSize = Math.max(3, +$attr.bufferSize || 10);
           bufferPadding = function() {
-            return viewport.height() * Math.max(0.1, +$attr.padding || 0.1);
+            return viewport.outerHeight() * Math.max(0.1, +$attr.padding || 0.1);
           };
           scrollHeight = function(elem) {
             var _ref;
@@ -197,7 +197,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
             return adjustBuffer(ridActual, false);
           };
           bottomVisiblePos = function() {
-            return viewport.scrollTop() + viewport.height();
+            return viewport.scrollTop() + viewport.outerHeight();
           };
           topVisiblePos = function() {
             return viewport.scrollTop();
@@ -206,17 +206,28 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
             return !eof && adapter.bottomDataPos() < bottomVisiblePos() + bufferPadding();
           };
           clipBottom = function() {
-            var bottomHeight, i, itemHeight, overage, _i, _ref;
+            var bottomHeight, i, item, itemHeight, itemTop, newRow, overage, rowTop, _i, _ref;
             bottomHeight = 0;
             overage = 0;
             for (i = _i = _ref = buffer.length - 1; _ref <= 0 ? _i <= 0 : _i >= 0; i = _ref <= 0 ? ++_i : --_i) {
-              itemHeight = buffer[i].element.outerHeight(true);
+              item = buffer[i];
+              itemTop = item.element.offset().top;
+              newRow = rowTop !== itemTop;
+              rowTop = itemTop;
+              if (newRow) {
+                itemHeight = item.element.outerHeight(true);
+              }
               if (adapter.bottomDataPos() - bottomHeight - itemHeight > bottomVisiblePos() + bufferPadding()) {
-                bottomHeight += itemHeight;
+                if (newRow) {
+                  bottomHeight += itemHeight;
+                }
                 overage++;
                 eof = false;
               } else {
-                break;
+                if (newRow) {
+                  break;
+                }
+                overage++;
               }
             }
             if (overage > 0) {
@@ -230,18 +241,28 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
             return !bof && (adapter.topDataPos() > topVisiblePos() - bufferPadding());
           };
           clipTop = function() {
-            var item, itemHeight, overage, topHeight, _i, _len;
+            var item, itemHeight, itemTop, newRow, overage, rowTop, topHeight, _i, _len;
             topHeight = 0;
             overage = 0;
             for (_i = 0, _len = buffer.length; _i < _len; _i++) {
               item = buffer[_i];
-              itemHeight = item.element.outerHeight(true);
+              itemTop = item.element.offset().top;
+              newRow = rowTop !== itemTop;
+              rowTop = itemTop;
+              if (newRow) {
+                itemHeight = item.element.outerHeight(true);
+              }
               if (adapter.topDataPos() + topHeight + itemHeight < topVisiblePos() - bufferPadding()) {
-                topHeight += itemHeight;
+                if (newRow) {
+                  topHeight += itemHeight;
+                }
                 overage++;
                 bof = false;
               } else {
-                break;
+                if (newRow) {
+                  break;
+                }
+                overage++;
               }
             }
             if (overage > 0) {
@@ -260,6 +281,15 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
               return fetch(rid, scrolling);
             }
           };
+          hideElementBeforeAppend = function(element) {
+            element.displayTemp = element.css('display');
+            return element.css('display', 'none');
+          };
+          showElementAfterRender = function(element) {
+            if (element.hasOwnProperty('displayTemp')) {
+              return element.css('display', element.displayTemp);
+            }
+          };
           insert = function(index, item) {
             var itemScope, toBeAppended, wrapper;
             itemScope = $scope.$new();
@@ -276,6 +306,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
               wrapper.element = clone;
               if (toBeAppended) {
                 if (index === next) {
+                  hideElementBeforeAppend(clone);
                   adapter.append(clone);
                   return buffer.push(wrapper);
                 } else {
@@ -283,6 +314,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
                   return buffer.splice(index - first + 1, 0, wrapper);
                 }
               } else {
+                hideElementBeforeAppend(clone);
                 adapter.prepend(clone);
                 return buffer.unshift(wrapper);
               }
@@ -305,48 +337,65 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
               }
             }
           };
-          adjustBuffer = function(rid, scrolling, newItems, finalize) {
-            var doAdjustment;
-            doAdjustment = function() {
-              var item, itemHeight, topHeight, _i, _len, _results;
-              log('top {actual=' + (adapter.topDataPos()) + ' visible from=' + (topVisiblePos()) + ' bottom {visible through=' + (bottomVisiblePos()) + ' actual=' + (adapter.bottomDataPos()) + '}');
-              if (shouldLoadBottom()) {
-                enqueueFetch(rid, true, scrolling);
-              } else {
-                if (shouldLoadTop()) {
-                  enqueueFetch(rid, false, scrolling);
-                }
+          doAdjustment = function(rid, scrolling, finalize) {
+            var item, itemHeight, itemTop, newRow, rowTop, topHeight, _i, _len, _results;
+            log('top {actual=' + (adapter.topDataPos()) + ' visible from=' + (topVisiblePos()) + ' bottom {visible through=' + (bottomVisiblePos()) + ' actual=' + (adapter.bottomDataPos()) + '}');
+            if (shouldLoadBottom()) {
+              enqueueFetch(rid, true, scrolling);
+            } else {
+              if (shouldLoadTop()) {
+                enqueueFetch(rid, false, scrolling);
               }
-              if (finalize) {
-                finalize(rid);
-              }
-              if (pending.length === 0) {
-                topHeight = 0;
-                _results = [];
-                for (_i = 0, _len = buffer.length; _i < _len; _i++) {
-                  item = buffer[_i];
+            }
+            if (finalize) {
+              finalize(rid);
+            }
+            if (pending.length === 0) {
+              topHeight = 0;
+              _results = [];
+              for (_i = 0, _len = buffer.length; _i < _len; _i++) {
+                item = buffer[_i];
+                itemTop = item.element.offset().top;
+                newRow = rowTop !== itemTop;
+                rowTop = itemTop;
+                if (newRow) {
                   itemHeight = item.element.outerHeight(true);
-                  if (adapter.topDataPos() + topHeight + itemHeight < topVisiblePos()) {
-                    _results.push(topHeight += itemHeight);
-                  } else {
-                    topVisible(item);
-                    break;
-                  }
                 }
-                return _results;
+                if (newRow && (adapter.topDataPos() + topHeight + itemHeight < topVisiblePos())) {
+                  _results.push(topHeight += itemHeight);
+                } else {
+                  if (newRow) {
+                    topVisible(item);
+                  }
+                  break;
+                }
               }
-            };
-            if (newItems) {
+              return _results;
+            }
+          };
+          adjustBuffer = function(rid, scrolling, newItems, finalize) {
+            if (newItems && newItems.length) {
               return $timeout(function() {
-                var row, _i, _len;
+                var itemTop, row, rowTop, rows, _i, _j, _len, _len1;
+                rows = [];
                 for (_i = 0, _len = newItems.length; _i < _len; _i++) {
                   row = newItems[_i];
+                  element = row.wrapper.element;
+                  showElementAfterRender(element);
+                  itemTop = element.offset().top;
+                  if (rowTop !== itemTop) {
+                    rows.push(row);
+                    rowTop = itemTop;
+                  }
+                }
+                for (_j = 0, _len1 = rows.length; _j < _len1; _j++) {
+                  row = rows[_j];
                   adjustRowHeight(row.appended, row.wrapper);
                 }
-                return doAdjustment();
+                return doAdjustment(rid, scrolling, finalize);
               });
             } else {
-              return doAdjustment();
+              return doAdjustment(rid, scrolling, finalize);
             }
           };
           finalize = function(rid, scrolling, newItems) {
@@ -373,10 +422,11 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
                     return;
                   }
                   newItems = [];
-                  if (result.length === 0) {
+                  if (result.length < bufferSize) {
                     eof = true;
                     adapter.bottomPadding(0);
-                  } else {
+                  }
+                  if (result.length > 0) {
                     clipTop();
                     for (_i = 0, _len = result.length; _i < _len; _i++) {
                       item = result[_i];
@@ -396,10 +446,11 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
                     return;
                   }
                   newItems = [];
-                  if (result.length === 0) {
+                  if (result.length < bufferSize) {
                     bof = true;
                     adapter.topPadding(0);
-                  } else {
+                  }
+                  if (result.length > 0) {
                     if (buffer.length) {
                       clipBottom();
                     }
@@ -426,6 +477,15 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
             }
           };
           viewport.bind('scroll', scrollHandler);
+          wheelHandler = function(event) {
+            var scrollTop, yMax;
+            scrollTop = viewport[0].scrollTop;
+            yMax = viewport[0].scrollHeight - viewport[0].clientHeight;
+            if ((scrollTop === 0 && !bof) || (scrollTop === yMax && !eof)) {
+              return event.preventDefault();
+            }
+          };
+          viewport.bind('mousewheel', wheelHandler);
           $scope.$watch(datasource.revision, function() {
             return reload();
           });
@@ -437,7 +497,8 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
           $scope.$on('$destroy', function() {
             eventListener.$destroy();
             viewport.unbind('resize', resizeHandler);
-            return viewport.unbind('scroll', scrollHandler);
+            viewport.unbind('scroll', scrollHandler);
+            return viewport.unbind('mousewheel', wheelHandler);
           });
           eventListener.$on('update.items', function(event, locator, newItem) {
             var wrapper, _fn, _i, _len, _ref;

--- a/modules/scroll/test/ScrollerSpec.js
+++ b/modules/scroll/test/ScrollerSpec.js
@@ -1,67 +1,111 @@
 /*global describe, beforeEach, module, inject, it, spyOn, expect, $ */
 describe('uiScroll', function () {
-	'use strict';
+    'use strict';
 
-	angular.module('ui.scroll.test', [])
-		.factory('myEmptyDatasource', [
-			function() {
-				var get = function(index, count, success) {
-					success([]);
-				};
+    angular.module('ui.scroll.test', [])
+        .factory('myEmptyDatasource', [
+            '$log', '$timeout', '$rootScope', function() {
+                return {
+                    get: function(index, count, success) {
+                        success([]);
+                    }
+                };
+            }
+        ])
 
+        .factory('myOnePageDatasource', [
+            '$log', '$timeout', '$rootScope', function() {
+                return {
+                    get: function(index, count, success) {
+                        if (index === 1) {
+                            success(['one', 'two', 'three']);
+                        } else {
+                            success([]);
+                        }
+                    }
+                };
+            }
+        ])
+
+        .factory('myMultipageDatasource', [
+            '$log', '$timeout', '$rootScope', function() {
+                return {
+                    get: function(index, count, success) {
+                        var result = [];
+                        for (var i = index; i<index+count; i++) {
+                            if (i>0 && i<=20)
+                                result.push('item' + i);
+                        }
+                        success(result);
+                    }
+                };
+            }
+        ])
+
+		.factory('AnotherDatasource', [
+			'$log', '$timeout', '$rootScope', function() {
 				return {
-					get: get
+					get: function(index, count, success) {
+                        var result = [];
+                        for (var i = index; i<index+count; i++) {
+                            if (i>-3 && i<1)
+                                result.push('item' + i);
+                        }
+                        success(result);
+                    }
 				};
 			}
 		])
 
-		.factory('myOnePageDatasource', [
-			function() {
-				var get = function(index, count, success) {
-					if (index === 1) {
-						success(['one', 'two', 'three']);
-					} else {
-						success([]);
+		.factory('myEdgeDatasource', [
+			'$log', '$timeout', '$rootScope', function() {
+				return {
+					get: function(index, count, success) {
+						var result = [];
+						for (var i = index; i<index+count; i++) {
+							if (i>-6 && i<=6)
+								result.push('item' + i);
+						}
+						success(result);
 					}
 				};
-
-				return {
-					get: get
-				};
 			}
 		])
 
-		.factory('myMultipageDatasource', [
-			function() {
-				var get = function(index, count, success) {
-					var result = [];
-					for (var i = index; i<index+count; i++) {
-						if (i>0 && i<=20) {
+		.factory('myDatasourceToPreventScrollBubbling', [
+			'$log', '$timeout', '$rootScope', function() {
+				return {
+					get: function(index, count, success) {
+						var result = [];
+						for (var i = index; i<index+count; i++) {
+							if (i<-6 || i>20) {
+								break;
+							}
 							result.push('item' + i);
 						}
+						success(result);
 					}
-					success(result);
-				};
-
-				return {
-					get: get
 				};
 			}
 		]);
 
-	beforeEach(module('ui.scroll'));
-	beforeEach(module('ui.scroll.test'));
+    beforeEach(module('ui.scroll'));
+    beforeEach(module('ui.scroll.test'));
 
-	var runTest = function(html, runTest, cleanupTest) {
+	var runTest = function(html, runTest, cleanupTest, options) {
 		inject(function($rootScope, $compile, $window, $timeout) {
 				var scroller = angular.element(html);
 				var scope = $rootScope.$new();
 				var sandbox = angular.element('<div/>');
 				angular.element(document).find('body').append(sandbox);
 				sandbox.append(scroller);
+
 				$compile(scroller)(scope);
 				scope.$apply();
-				$timeout.flush();
+
+				if(!options || !options.noFlush) {
+					$timeout.flush();
+				}
 
 				runTest($window, sandbox);
 
@@ -78,24 +122,31 @@ describe('uiScroll', function () {
 	describe('basic setup', function() {
 			var html = '<div ui-scroll="item in myEmptyDatasource">{{$index}}: {{item}}</div>';
 
-			it('should bind to window scroll and resize events and unbind upon scope destroy', function(){
+				it('should bind to window scroll and resize events and unbind upon scope destroy', function(){
 				spyOn($.fn, 'bind').andCallThrough();
 				spyOn($.fn, 'unbind').andCallThrough();
 				runTest(html,
 					function($window) {
-						expect($.fn.bind.calls.length).toBe(2);
+						expect($.fn.bind.calls.length).toBe(3);
 						expect($.fn.bind.calls[0].args[0]).toBe('resize');
 						expect($.fn.bind.calls[0].object[0]).toBe($window);
 						expect($.fn.bind.calls[1].args[0]).toBe('scroll');
 						expect($.fn.bind.calls[1].object[0]).toBe($window);
+						expect($.fn.bind.calls[2].args[0]).toBe('mousewheel');
+						expect($.fn.bind.calls[2].object[0]).toBe($window);
 						expect($._data($window, 'events')).toBeDefined();
 					},
 					function($window) {
-						expect($.fn.unbind.calls.length).toBe(2);
+						expect($.fn.unbind.calls.length).toBe(3);
 						expect($.fn.unbind.calls[0].args[0]).toBe('resize');
 						expect($.fn.unbind.calls[0].object[0]).toBe($window);
 						expect($.fn.unbind.calls[1].args[0]).toBe('scroll');
 						expect($.fn.unbind.calls[1].object[0]).toBe($window);
+						expect($.fn.unbind.calls[2].args[0]).toBe('mousewheel');
+						expect($.fn.unbind.calls[2].object[0]).toBe($window);
+					},
+					{
+						noFlush: true //empty data-set; nothing to render
 					}
 				);
 			});
@@ -113,6 +164,8 @@ describe('uiScroll', function () {
 						expect(bottomPadding.tagName.toLowerCase()).toBe('div');
 						expect(angular.element(bottomPadding).css('height')).toBe('0px');
 
+					}, null, {
+						noFlush: true
 					}
 				);
 			});
@@ -128,6 +181,8 @@ describe('uiScroll', function () {
 						expect(spy.calls[0].args[0]).toBe(1);
 						expect(spy.calls[1].args[0]).toBe(-9);
 
+					}, null, {
+						noFlush: true
 					}
 				);
 			});
@@ -158,24 +213,63 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should call get on the datasource 3 times ', function() {
+		it('should call get on the datasource 2 times ', function() {
 			var spy;
 			inject(function(myOnePageDatasource){
 				spy = spyOn(myOnePageDatasource, 'get').andCallThrough();
+			runTest(html,
+				function() {
+					expect(spy.calls.length).toBe(2);
+
+					expect(spy.calls[0].args[0]).toBe(1);  // gets 3 rows (with eof)
+					expect(spy.calls[1].args[0]).toBe(-9); // gets 0 rows (and bof)
+				});
+			});
+
+		});
+	});
+
+	describe('datasource with only 3 elements (negative index)', function () {
+
+		var html = '<div ui-scroll="item in AnotherDatasource">{{$index}}: {{item}}</div>';
+
+		it('should create 3 divs with data (+ 2 padding divs)', function() {
+			runTest(html,
+				function($window, sandbox) {
+					expect(sandbox.children().length).toBe(5);
+
+					var row1 = sandbox.children()[1];
+					expect(row1.tagName.toLowerCase()).toBe('div');
+					expect(row1.innerHTML).toBe('-2: item-2');
+
+					var row2 = sandbox.children()[2];
+					expect(row2.tagName.toLowerCase()).toBe('div');
+					expect(row2.innerHTML).toBe('-1: item-1');
+
+					var row3 = sandbox.children()[3];
+					expect(row3.tagName.toLowerCase()).toBe('div');
+					expect(row3.innerHTML).toBe('0: item0');
+				}
+			);
+		});
+
+		it('should call get on the datasource 2 times ', function() {
+			var spy;
+			inject(function(AnotherDatasource){
+				spy = spyOn(AnotherDatasource, 'get').andCallThrough();
 				runTest(html,
 					function() {
-						expect(spy.calls.length).toBe(3);
+						expect(spy.calls.length).toBe(2);
 
-						expect(spy.calls[0].args[0]).toBe(1);  // gets 3 rows
-						expect(spy.calls[1].args[0]).toBe(4);  // gets eof
-						expect(spy.calls[2].args[0]).toBe(-9); // gets bof
+						expect(spy.calls[0].args[0]).toBe(1);  // gets 0 rows (and eof)
+						expect(spy.calls[1].args[0]).toBe(-9); // gets 3 rows (and bof)
 					});
 			});
 
 		});
 	});
 
-	describe('datasource with 20 elements default buffer size (10) - constrained viewport', function () {
+	describe('datasource with 20 elements and buffer size 3 - constrained viewport', function () {
 
 		var html = '<div ui-scroll-viewport style="height:200px"><div style="height:40px" ui-scroll="item in myMultipageDatasource" buffer-size="3">{{$index}}: {{item}}</div></div>';
 
@@ -382,5 +476,193 @@ describe('uiScroll', function () {
 		});
 
 	});
+
+    describe('datasource with 12 elements and buffer size 3 (fold/edge cases)', function () {
+
+        var itemsCount = 12, buffer = 3, itemHeight = 20;
+        var makeHtml = function (viewportHeight) {
+            return '<div ui-scroll-viewport style="height:' + viewportHeight + 'px"><div style="height:' + itemHeight + 'px" ui-scroll="item in myEdgeDatasource" buffer-size="' + buffer + '">{{$index}}: {{item}}</div></div>';
+        };
+
+        it('[full frame] should call get on the datasource 4 (12/3) times + 2 additional times (with empty result)', function() {
+            var spy;
+            var viewportHeight = itemsCount * itemHeight;
+
+            inject(function(myEdgeDatasource){
+                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+            });
+
+            runTest(makeHtml(viewportHeight),
+                function() {
+                    expect(spy.calls.length).toBe(parseInt(itemsCount/buffer, 10) + 2);
+
+                    expect(spy.calls[0].args[0]).toBe(1);
+                    expect(spy.calls[1].args[0]).toBe(4);
+                    expect(spy.calls[2].args[0]).toBe(7);
+                    expect(spy.calls[3].args[0]).toBe(-2);
+                    expect(spy.calls[4].args[0]).toBe(-5);
+                    expect(spy.calls[5].args[0]).toBe(-8);
+                }
+            );
+        });
+
+        it('[fold frame] should call get on the datasource 3 times', function() {
+            var spy;
+            var viewportHeight = buffer * itemHeight;
+
+            inject(function(myEdgeDatasource){
+                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+            });
+
+            runTest(makeHtml(viewportHeight),
+                function() {
+                    expect(spy.calls.length).toBe(3);
+
+                    expect(spy.calls[0].args[0]).toBe(1);
+                    expect(spy.calls[1].args[0]).toBe(4);
+                    expect(spy.calls[2].args[0]).toBe(-2);
+                }
+            );
+        });
+
+        it('[fold frame, scroll down] should call get on the datasource 1 extra time', function() {
+            var spy, flush;
+            var viewportHeight = buffer * itemHeight;
+
+            inject(function (myEdgeDatasource) {
+                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+            });
+            inject(function ($timeout) {
+                flush = $timeout.flush;
+            });
+
+            runTest(makeHtml(viewportHeight),
+                function($window, sandbox) {
+                    var scroller = sandbox.children();
+                    scroller.scrollTop(viewportHeight + itemHeight);
+                    scroller.trigger('scroll');
+                    flush();
+                    scroller.scrollTop(viewportHeight + itemHeight * 2);
+                    scroller.trigger('scroll');
+                    expect(flush).toThrow();
+
+                    expect(spy.calls.length).toBe(4);
+
+                    expect(spy.calls[0].args[0]).toBe(1);
+                    expect(spy.calls[1].args[0]).toBe(4); //last full
+                    expect(spy.calls[2].args[0]).toBe(-2);
+                    expect(spy.calls[3].args[0]).toBe(5); //empty
+
+                }
+            );
+        });
+
+        it('[fold frame, scroll up] should call get on the datasource 2 extra times', function() {
+            var spy, flush;
+            var viewportHeight = buffer * itemHeight;
+
+            inject(function (myEdgeDatasource) {
+                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+            });
+            inject(function ($timeout) {
+                flush = $timeout.flush;
+            });
+
+            runTest(makeHtml(viewportHeight),
+                function($window, sandbox) {
+                    var scroller = sandbox.children();
+                    scroller.scrollTop(0); //first full, scroll to -2
+                    scroller.trigger('scroll');
+                    flush();
+                    scroller.scrollTop(0); //last full, scroll to -5, bof is reached
+                    scroller.trigger('scroll');
+                    expect(flush).toThrow();
+                    scroller.scrollTop(0); //empty, no scroll occured (-8)
+                    scroller.trigger('scroll');
+                    expect(flush).toThrow();
+
+                    expect(spy.calls.length).toBe(5);
+
+                    expect(spy.calls[0].args[0]).toBe(1);
+                    expect(spy.calls[1].args[0]).toBe(4);
+                    expect(spy.calls[2].args[0]).toBe(-2); //first full
+                    expect(spy.calls[3].args[0]).toBe(-5); //last full
+                    expect(spy.calls[4].args[0]).toBe(-8); //empty
+
+                }
+            );
+        });
+
+    });
+
+
+    describe('prevent unwanted scroll bubbling', function () {
+
+        var commonHtml = '<div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;"><ul><li ui-scroll="item in myDatasourceToPreventScrollBubbling" buffer-size="3">{{$index}}: {{item}}</li></ul></div>';
+        var documentScrollBubblingCount = 0;
+        var incrementDocumentScrollCount = function(event) {
+            event = event.originalEvent || event;
+            if(!event.defaultPrevented) {
+                documentScrollBubblingCount++;
+            }
+        };
+        var getNewWheelEvent = function () {
+            var event = document.createEvent('MouseEvents');
+            event.initEvent('mousewheel', true, true);
+            event.wheelDelta = 120;
+            return event;
+        };
+
+        it('should prevent wheel-event bubbling until bof is reached', function() {
+            var spy, flush;
+
+            inject(function (myDatasourceToPreventScrollBubbling) {
+                spy = spyOn(myDatasourceToPreventScrollBubbling, 'get').andCallThrough();
+            });
+            inject(function ($timeout) {
+                flush = $timeout.flush;
+            });
+
+            runTest(commonHtml,
+                function($window, sandbox) {
+                    var scroller = sandbox.children();
+                    var wheelEventElement = scroller[0];
+
+                    angular.element(document.body).bind('mousewheel', incrementDocumentScrollCount); //spy for wheel-events bubbling
+
+                    //simulate multiple wheel-scroll events within viewport
+
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred but document will not scroll because of viewport will be scrolled
+                    expect(documentScrollBubblingCount).toBe(1);
+
+                    scroller.scrollTop(0);
+                    scroller.trigger('scroll');
+
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //now we are at top but preventDefault will occur because of bof will be reached only after next scroll trigger
+                    expect(documentScrollBubblingCount).toBe(1); //here! the only one prevented wheel-event
+
+                    flush();
+
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred but document will not scroll because of viewport will be scrolled
+                    expect(documentScrollBubblingCount).toBe(2);
+
+                    scroller.scrollTop(0);
+                    scroller.trigger('scroll'); //bof will be reach here
+
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred because we are at top and bof is reached
+                    expect(documentScrollBubblingCount).toBe(3);
+
+                    expect(flush).toThrow(); //there is no new data, bof is reached
+
+                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred because we are at top and bof is reached
+                    expect(documentScrollBubblingCount).toBe(4);
+
+                }, function() {
+                    angular.element(document.body).unbind('mousewheel', incrementDocumentScrollCount);
+                }
+            );
+
+        });
+    });
 
 });


### PR DESCRIPTION
v.1.0.0 changelog
- Renamed ng-scroll to ui-scroll.
- Reduced server requests by eof and bof recalculation.
- Support for inline-block/floated elements.
- Reduced flickering via new blocks rendering optimization.
- Prevented unwanted scroll bubbling.
- Fixed race-condition and others minor bugs.
- Added more usage examples (such as cache within datasource implementation).
