### PR TITLE
use stricter versions in bower.json for a more stable build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,10 @@
   "homepage": "http://angular-ui.github.com",
   "main": "./modules/utils.js",
   "dependencies": {
-    "angular": ">= 1.0.2"
+    "angular": "~1.0.8"
   },
   "devDependencies": {
     "angular-mocks": "~1.0.5",
-    "jquery": ">=1.6"
+    "jquery": "~2.1.1"
   }
 }


### PR DESCRIPTION
This way new incompatible angular- or jquery-releases don't break the build for all versions in the history.
