### PR TITLE
scroll-jqlite.js conflict with jQuery CSS getter function

### DIFF
--- a/modules/scroll/scroll-jqlite.js
+++ b/modules/scroll/scroll-jqlite.js
@@ -10,7 +10,11 @@ angular.module('ui.scroll.jqlite', ['ui.scroll']).service('jqLiteExtras', [
           self = this;
           elem = self[0];
           if (!(!elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style)) {
-            return css.call(self, name, value);
+            if(value == undefined) {
+              return css.call(self, name);
+            } else {
+              return css.call(self, name, value);
+            }
           }
         };
         isWindow = function(obj) {

--- a/modules/scroll/scroll-jqlite.js
+++ b/modules/scroll/scroll-jqlite.js
@@ -10,7 +10,7 @@ angular.module('ui.scroll.jqlite', ['ui.scroll']).service('jqLiteExtras', [
           self = this;
           elem = self[0];
           if (!(!elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style)) {
-            if(value == undefined) {
+            if(value === undefined) {
               return css.call(self, name);
             } else {
               return css.call(self, name, value);


### PR DESCRIPTION
Since jQuery is being used and not jqLite in this case, the css call is passing the wrong number of parameters, causing jQuery to not see it as a getter call. 

I added a simple check to either pass the value argument or not.
