### PR TITLE
fixed issue related to checking offset on target rather than only window...

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -27,7 +27,11 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
         // if pageYOffset is defined use it, otherwise use other crap for IE
         var offset;
         if (angular.isDefined($window.pageYOffset)) {
-          offset = $window.pageYOffset;
+          if ($target[0] === $window) {
+            offset = $window.pageYOffset;
+          } else {
+            offset = $target[0].scrollTop;
+          }
         } else {
           var iebody = (document.compatMode && document.compatMode !== 'BackCompat') ? document.documentElement : document.body;
           offset = iebody.scrollTop;

--- a/modules/scrollfix/test/scrollfixSpec.js
+++ b/modules/scrollfix/test/scrollfixSpec.js
@@ -53,4 +53,24 @@ describe('uiScrollfix', function () {
       expect(element.hasClass('ui-scrollfix')).toBe(false);
     });
   });
+  describe('scrolling the target', function () {
+    it('should add the ui-scrollfix class if the offset is greater than specified', function () {
+      var target = angular.element($compile('<div ui-scrollfix-target><div id="elm" ui-scrollfix="-100"></div></div>')(scope));
+      target.trigger('scroll');
+      var element = angular.element(target.children()[0]);
+      expect(element.hasClass('ui-scrollfix')).toBe(true);
+    });
+    it('should remove the ui-scrollfix class if the offset is less than specified (using absolute coord)', function () {
+      var target = angular.element($compile('<div ui-scrollfix-target><div id="elm" ui-scrollfix="100"></div></div>')(scope));
+      target.trigger('scroll');
+      var element = angular.element(target.children()[0]);
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+    });
+    it('should remove the ui-scrollfix class if the offset is less than specified (using relative coord)', function () {
+      var target = angular.element($compile('<div ui-scrollfix-target><div id="elm" ui-scrollfix="+100"></div></div>')(scope));
+      target.trigger('scroll');
+      var element = angular.element(target.children()[0]);
+      expect(element.hasClass('ui-scrollfix')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
I was having a hard time figuring out why scrollfix was not working in my app, and noticed that the offset is always pulled from `$window`.

This is insufficient as it will not properly work when you have an absolutely positioned container for the main viewport of an app.

I have fixed this by having the offset from the `$target` since it will always default to $window when a parent `ui-scrollfix-target` is not found.

I also have the corresponding passing tests...
