### PR TITLE
fix(highlight): ng-bind-html-unsafe is not available in 1.2+

### DIFF
--- a/modules/highlight/demo/index.html
+++ b/modules/highlight/demo/index.html
@@ -17,14 +17,14 @@
 
     <p><input placeholder="Enter some text to highlight" ng-model="highlightText"></p>
 
-    <p ng-bind-html-unsafe="'Hello there, how are you today? I\'m fine thank you.' | highlight:highlightText:caseSensitive"></p>
+    <p ng-bind-html="'Hello there, how are you today? I\'m fine thank you.' | highlight:highlightText:caseSensitive"></p>
   </div>
 
   <h3>How?</h3>
 <pre class="prettyprint">
 &lt;label&gt;&lt;input type=&quot;checkbox&quot; ng-model=&quot;caseSensitive&quot;&gt; Case Sensitive?&lt;/label&gt;
 &lt;input placeholder=&quot;Enter some text to highlight&quot; value=&quot;you&quot; ng-model=&quot;highlightText&quot;&gt;
-&lt;p ng-bind-html-unsafe=&quot;&#x27;Hello there, how are you today? I\'m fine thank you.&#x27; | highlight:highlightText:caseSensitive&quot;&gt;&lt;/p&gt;
+&lt;p ng-bind-html=&quot;&#x27;Hello there, how are you today? I\'m fine thank you.&#x27; | highlight:highlightText:caseSensitive&quot;&gt;&lt;/p&gt;
 
 &lt;style&gt;
 .ui-match { background: yellow; }

--- a/modules/highlight/highlight.js
+++ b/modules/highlight/highlight.js
@@ -6,18 +6,18 @@
  * @param search {string} needle to search for
  * @param [caseSensitive] {boolean} optional boolean to use case-sensitive searching
  */
-angular.module('ui.highlight',[]).filter('highlight', function () {
+angular.module('ui.highlight',[]).filter('highlight', [ '$sce' , function ($sce) {
   return function (text, search, caseSensitive) {
     if (search || angular.isNumber(search)) {
       text = text.toString();
       search = search.toString();
       if (caseSensitive) {
-        return text.split(search).join('<span class="ui-match">' + search + '</span>');
+        return $sce.trustAsHtml(text.split(search).join('<span class="ui-match">' + search + '</span>'));
       } else {
-        return text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>');
+        return $sce.trustAsHtml(text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>'));
       }
     } else {
-      return text;
+      return $sce.trustAsHtml(text);
     }
   };
-});
+}]);

--- a/modules/highlight/test/highlightSpec.js
+++ b/modules/highlight/test/highlightSpec.js
@@ -1,50 +1,51 @@
 describe('highlight', function () {
   'use strict';
 
-  var highlightFilter, testPhrase = 'Prefix Highlight Suffix';
+  var highlightFilter, sce, testPhrase = 'Prefix Highlight Suffix';
 
   beforeEach(module('ui.highlight'));
-  beforeEach(inject(function ($filter) {
+  beforeEach(inject(function ($filter, $sce) {
     highlightFilter = $filter('highlight');
+    sce = $sce;
   }));
   describe('case insensitive', function () {
     it('should highlight a matching phrase', function () {
-      expect(highlightFilter(testPhrase, 'highlight')).toEqual('Prefix <span class="ui-match">Highlight</span> Suffix');
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, 'highlight'))).toEqual('Prefix <span class="ui-match">Highlight</span> Suffix');
     });
     it('should highlight nothing if no match found', function () {
-      expect(highlightFilter(testPhrase, 'no match')).toEqual(testPhrase);
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, 'no match'))).toEqual(testPhrase);
     });
     it('should highlight nothing for the undefined filter', function () {
-      expect(highlightFilter(testPhrase, undefined)).toEqual(testPhrase);
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, undefined))).toEqual(testPhrase);
     });
     it('should work correctly for number filters', function () {
-      expect(highlightFilter('3210123', 0)).toEqual('321<span class="ui-match">0</span>123');
+      expect(sce.getTrusted(sce.HTML, highlightFilter('3210123', 0))).toEqual('321<span class="ui-match">0</span>123');
     });
     it('should work correctly for number text', function () {
-      expect(highlightFilter(3210123, '0')).toEqual('321<span class="ui-match">0</span>123');
+      expect(sce.getTrusted(sce.HTML, highlightFilter(3210123, '0'))).toEqual('321<span class="ui-match">0</span>123');
     });
   });
   describe('case sensitive', function () {
     it('should highlight a matching phrase', function () {
-      expect(highlightFilter(testPhrase, 'Highlight', true)).toEqual('Prefix <span class="ui-match">Highlight</span> Suffix');
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, 'Highlight', true))).toEqual('Prefix <span class="ui-match">Highlight</span> Suffix');
     });
     it('should highlight nothing if no match found', function () {
-      expect(highlightFilter(testPhrase, 'no match', true)).toEqual(testPhrase);
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, 'no match', true))).toEqual(testPhrase);
     });
     it('should highlight nothing for the undefined filter', function () {
-      expect(highlightFilter(testPhrase, undefined, true)).toEqual(testPhrase);
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, undefined, true))).toEqual(testPhrase);
     });
     it('should work correctly for number filters', function () {
-      expect(highlightFilter('3210123', 0, true)).toEqual('321<span class="ui-match">0</span>123');
+      expect(sce.getTrusted(sce.HTML, highlightFilter('3210123', 0, true))).toEqual('321<span class="ui-match">0</span>123');
     });
     it('should work correctly for number text', function () {
-      expect(highlightFilter(3210123, '0', true)).toEqual('321<span class="ui-match">0</span>123');
+      expect(sce.getTrusted(sce.HTML, highlightFilter(3210123, '0', true))).toEqual('321<span class="ui-match">0</span>123');
     });
     it('should not highlight a phrase with different letter-casing', function () {
-      expect(highlightFilter(testPhrase, 'highlight', true)).toEqual(testPhrase);
+      expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, 'highlight', true))).toEqual(testPhrase);
     });
   });
   it('should highlight nothing if empty filter string passed - issue #114', function () {
-    expect(highlightFilter(testPhrase, '')).toEqual(testPhrase);
+    expect(sce.getTrusted(sce.HTML, highlightFilter(testPhrase, ''))).toEqual(testPhrase);
   });
 });


### PR DESCRIPTION
#### Issue

`ng-bind-html-unsafe` is not available in 1.2+ so we have to use `ng-bind-html`, but these need trusted data
#### Changes
1. Changed demo html to use `ng-bind-html-unsafe` to `ng-bind-html`
2. Filter now returns trusted html using `$sce` provided by angular
3. Updated test cases to convert the filtered value to html using `sce.getTrusted(sce.HTML, trustedHtml)` , before comparing with test phrase
