### PR TITLE
ui-mask Fix: Field gets set to dirty when it loses focus.

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -295,7 +295,9 @@ angular.module('ui.mask', [])
               valueMasked = '';
               iElement.val('');
               scope.$apply(function (){
-                controller.$setViewValue('');
+                if (controller.$dirty) {
+                  controller.$setViewValue('');
+                }
               });
             }
           }


### PR DESCRIPTION
Masked inputs were being set to $dirty even though they hadn't had any changes on them. This makes sure we don't update the model if no changes were made to the field.

To reproduce the problem:
- Click on a masked field
- Lose focus on the field
- Check field status, it should be marked as dirty even though you made no changes to it.
