### PR TITLE
mask: Use $viewValue instead of $modelValue in initializeElement()

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -147,7 +147,7 @@ angular.module('ui.mask', [])
           }
 
           function initializeElement(){
-            value = oldValueUnmasked = unmaskValue(controller.$modelValue || '');
+            value = oldValueUnmasked = unmaskValue(controller.$viewValue || '');
             valueMasked = oldValue = maskValue(value);
             isValid = validateValue(value);
             var viewValue = isValid && value.length ? valueMasked : '';


### PR DESCRIPTION
This fixes an issue when ui-mask is used together with other directives
that have $formatters modifying the $modelValue.