### PR TITLE
Add a "default-character" attribute to ui-mask

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -226,11 +226,20 @@ angular.module('ui.mask', [])
 
           function getPlaceholderChar(i) {
             var placeholder = iAttrs.placeholder;
+            var default_placeholder_char = '_';
 
             if (typeof placeholder !== 'undefined' && placeholder[i]) {
               return placeholder[i];
             } else {
-              return '_';
+              if (undefined !== iAttrs.defaultCharacter) {
+                if ('' === iAttrs.defaultCharacter) {
+                  default_placeholder_char = ' ';
+                } else {
+                  default_placeholder_char = iAttrs.defaultCharacter[0];
+                }
+              }
+
+              return default_placeholder_char;
             }
           }
 

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -192,6 +192,51 @@ describe("uiMask", function () {
       expect(input.attr("placeholder")).toBe("__/__/____");
     });
 
+    it("should allow changing the default character", function() {
+
+      var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' default-character='Z'>",
+          input           = compileElement(placeholderHtml);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '99/99/9999'");
+
+      expect(input.attr("placeholder")).toBe("ZZ/ZZ/ZZZZ");
+
+      input.val("12").triggerHandler("input");
+
+      expect(input.val()).toBe("12/ZZ/ZZZZ");
+    });
+
+    it("should allow the default character to be a space", function() {
+
+      var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' default-character=' '>",
+          input           = compileElement(placeholderHtml);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '99/99/9999'");
+
+      expect(input.attr("placeholder")).toBe("  /  /    ");
+
+      input.val("12").triggerHandler("input");
+
+      expect(input.val()).toBe("12/  /    ");
+    });
+
+    it("should allow the default character to interpret an empty string as a space", function() {
+
+      var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' default-character=''>",
+          input           = compileElement(placeholderHtml);
+
+      scope.$apply("x = ''");
+      scope.$apply("mask = '99/99/9999'");
+
+      expect(input.attr("placeholder")).toBe("  /  /    ");
+
+      input.val("12").triggerHandler("input");
+
+      expect(input.val()).toBe("12/  /    ");
+    });
+
     it("should allow mask substitutions via the placeholder attribute", function() {
 
       var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' placeholder='MM/DD/YYYY'>",


### PR DESCRIPTION
Add a "default-character" attribute to ui-mask to allow user to define a default character other than "_". Interprets an empty string as a space.
