### PR TITLE
[ui.mask]: Adding new option ui-mask-raw to enable/disable binding the raw or view value to the masked input model.

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -120,8 +120,8 @@ angular.module('ui.mask', [])
 
           iAttrs.$observe('uiMask', initialize);
           iAttrs.$observe('uiMaskRaw', function (val) {
-        	  if (val !== undefined)
-        		  localMaskRaw = (val != 'false');
+              if (val !== undefined)
+                  localMaskRaw = (val != 'false');
           });
           iAttrs.$observe('placeholder', initPlaceholder);
           var modelViewValue = false;

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -19,7 +19,7 @@ angular.module('ui.mask', [])
       restrict: 'A',
       compile: function uiMaskCompilingFunction(){
         var options = maskConfig,
-        	globalMaskRaw = maskRaw;
+            globalMaskRaw = maskRaw;
 
         return function uiMaskLinkingFunction(scope, iElement, iAttrs, controller){
           var maskProcessed = false, eventsBound = false,
@@ -82,11 +82,11 @@ angular.module('ui.mask', [])
             // value performed by eventHandler() doesn't happen until after
             // this parser is called, which causes what the user sees in the input
             // to be out-of-sync with what the controller's $viewValue is set to.
-            if (localMaskRaw == true) {
-            	controller.$viewValue = value.length ? maskValue(value) : '';
+            if (localMaskRaw === true) {
+                controller.$viewValue = value.length ? maskValue(value) : '';
             } else {
-            	value = value.length ? maskValue(value) : '';
-            	controller.$viewValue = value;
+                value = value.length ? maskValue(value) : '';
+                controller.$viewValue = value;
             }
             controller.$setValidity('mask', isValid);
             if (value === '' && iAttrs.required) {
@@ -120,8 +120,8 @@ angular.module('ui.mask', [])
 
           iAttrs.$observe('uiMask', initialize);
           iAttrs.$observe('uiMaskRaw', function (val) {
-        	  if (val != undefined)
-        		  localMaskRaw = !(val == 'false');
+        	  if (val !== undefined)
+        		  localMaskRaw = (val != 'false');
           });
           iAttrs.$observe('placeholder', initPlaceholder);
           var modelViewValue = false;

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -11,13 +11,15 @@ angular.module('ui.mask', [])
       '*': /[a-zA-Z0-9]/
     }
   })
-  .directive('uiMask', ['uiMaskConfig', '$parse', function (maskConfig, $parse) {
+  .value('uiMaskRaw', true)
+  .directive('uiMask', ['uiMaskConfig', 'uiMaskRaw', '$parse', function (maskConfig, maskRaw, $parse) {
     return {
       priority: 100,
       require: 'ngModel',
       restrict: 'A',
       compile: function uiMaskCompilingFunction(){
-        var options = maskConfig;
+        var options = maskConfig,
+        	globalMaskRaw = maskRaw;
 
         return function uiMaskLinkingFunction(scope, iElement, iAttrs, controller){
           var maskProcessed = false, eventsBound = false,
@@ -29,7 +31,10 @@ angular.module('ui.mask', [])
             originalPlaceholder = iAttrs.placeholder,
             originalMaxlength = iAttrs.maxlength,
           // Vars used exclusively in eventHandler()
-            oldValue, oldValueUnmasked, oldCaretPosition, oldSelectionLength;
+            oldValue, oldValueUnmasked, oldCaretPosition, oldSelectionLength,
+          // Var to override locally the uiMaskRaw global config.
+            localMaskRaw = globalMaskRaw
+          ;
 
           function initialize(maskAttr){
             if (!angular.isDefined(maskAttr)) {
@@ -77,7 +82,12 @@ angular.module('ui.mask', [])
             // value performed by eventHandler() doesn't happen until after
             // this parser is called, which causes what the user sees in the input
             // to be out-of-sync with what the controller's $viewValue is set to.
-            controller.$viewValue = value.length ? maskValue(value) : '';
+            if (localMaskRaw == true) {
+            	controller.$viewValue = value.length ? maskValue(value) : '';
+            } else {
+            	value = value.length ? maskValue(value) : '';
+            	controller.$viewValue = value;
+            }
             controller.$setValidity('mask', isValid);
             if (value === '' && iAttrs.required) {
               controller.$setValidity('required', false);
@@ -109,6 +119,10 @@ angular.module('ui.mask', [])
           }
 
           iAttrs.$observe('uiMask', initialize);
+          iAttrs.$observe('uiMaskRaw', function (val) {
+        	  if (val != undefined)
+        		  localMaskRaw = !(val == 'false');
+          });
           iAttrs.$observe('placeholder', initPlaceholder);
           var modelViewValue = false;
           iAttrs.$observe('modelViewValue', function(val) {


### PR DESCRIPTION
Following the implementation proposed by @Snede in #199 i improved the implementation of this extremely needed feature.
I added a global configuration in the ui.mask module called uiMaskRaw (as suggested by @ProLoser).
If it is set to true (default) the behavior is the same that we have today, the raw value is assigned to the model.
If it is switched off (false) the view value (masked value) is assigned to the model.

I also observes the ui-mask-raw attribute to override this configuration locally, as follows:

```
<input type='text' ui-mask='(999) 999-9999' ui-mask-raw='false' />
```

That way you can set the global behavior and the individual input behavior.
