### PR TITLE
Paceholder when mask has optional characters

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -257,6 +257,7 @@ angular.module('ui.mask', [])
               minRequiredLength = 0;
 
               var isOptional = false,
+                  numberOfOptionalCharacters = 0,
                   splitMask  = mask.split('');
 
               angular.forEach(splitMask, function (chr, i){
@@ -264,7 +265,7 @@ angular.module('ui.mask', [])
 
                   maskCaretMap.push(characterCount);
 
-                  maskPlaceholder += getPlaceholderChar(i);
+                  maskPlaceholder += getPlaceholderChar(i - numberOfOptionalCharacters);
                   maskPatterns.push(linkOptions.maskDefinitions[chr]);
 
                   characterCount++;
@@ -274,6 +275,7 @@ angular.module('ui.mask', [])
                 }
                 else if (chr === '?') {
                   isOptional = true;
+                  numberOfOptionalCharacters++;
                 }
                 else {
                   maskPlaceholder += chr;

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -227,6 +227,13 @@ describe("uiMask", function () {
       expect(input.attr("placeholder")).toBe("MM/DD/YYYY");
     });
 
+    it("should ignore the '?' character", function() {
+      var placeholderHtml = "<input type=\"text\" ui-mask=\"99/99/9999 ?99:99\" placeholder=\"DD/MM/YYYY HH:mm\" ng-model=\"myDate\">",
+        input = compileElement(placeholderHtml);
+
+      scope.$apply("myDate = ''");
+      expect(input.attr("placeholder")).toBe("DD/MM/YYYY HH:mm");
+    });
 
   });
 


### PR DESCRIPTION
I was using the optional part mask (https://github.com/angular-ui/ui-utils/pull/21) and noted that the placeholder was not working as I expected (see this plunker: http://plnkr.co/edit/8d1rduAM7ag5CxOkFx1U?p=preview).

So I made this pull request with the code that solved this problem.