### PR TITLE
Prepare ui mask for Angular 1.3

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -66,7 +66,7 @@ angular.module('ui.mask', [])
             value = unmaskValue(fromModelValue || '');
             isValid = validateValue(value);
             ngModel.$setValidity('mask', isValid);
-            return isValid && value.length ? maskValue(value) : undefined;
+            return isValid && value.length ? maskValue(value) : allowInvalid(maskValue(value), undefined);
           }
 
           function allowInvalid(valid, invalid) {
@@ -86,7 +86,7 @@ angular.module('ui.mask', [])
             // value performed by eventHandler() doesn't happen until after
             // this parser is called, which causes what the user sees in the input
             // to be out-of-sync with what the controller's $viewValue is set to.
-            ngModel.$viewValue = value.length ? maskValue(value) : '';
+            ngModel.$viewValue = value.length ? maskValue(value) : allowInvalid(maskValue(value), '');
             ngModel.$setValidity('mask', isValid);
             if (value === '' && iAttrs.required) {
               ngModel.$setValidity('required', false);

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -14,7 +14,7 @@ angular.module('ui.mask', [])
   .directive('uiMask', ['uiMaskConfig', '$parse', function (maskConfig, $parse) {
     return {
       priority: 100,
-      require: 'ngModel',
+      require: ['ngModel','?ngModelOptions'],
       restrict: 'A',
       compile: function uiMaskCompilingFunction(){
         var options = maskConfig;
@@ -28,6 +28,8 @@ angular.module('ui.mask', [])
           // Vars for initializing/uninitializing
             originalPlaceholder = iAttrs.placeholder,
             originalMaxlength = iAttrs.maxlength,
+            ngModel = controller[0],
+            ngModelOptions = controller[1],
           // Vars used exclusively in eventHandler()
             oldValue, oldValueUnmasked, oldCaretPosition, oldSelectionLength;
 
@@ -63,8 +65,15 @@ angular.module('ui.mask', [])
             }
             value = unmaskValue(fromModelValue || '');
             isValid = validateValue(value);
-            controller.$setValidity('mask', isValid);
+            ngModel.$setValidity('mask', isValid);
             return isValid && value.length ? maskValue(value) : undefined;
+          }
+
+          function allowInvalid(valid, invalid) {
+            if (ngModelOptions && ngModelOptions.$options && ngModelOptions.$options.allowInvalid === true) {
+              return valid;
+            }
+            return invalid;
           }
 
           function parser(fromViewValue){
@@ -77,12 +86,12 @@ angular.module('ui.mask', [])
             // value performed by eventHandler() doesn't happen until after
             // this parser is called, which causes what the user sees in the input
             // to be out-of-sync with what the controller's $viewValue is set to.
-            controller.$viewValue = value.length ? maskValue(value) : '';
-            controller.$setValidity('mask', isValid);
+            ngModel.$viewValue = value.length ? maskValue(value) : '';
+            ngModel.$setValidity('mask', isValid);
             if (value === '' && iAttrs.required) {
-              controller.$setValidity('required', false);
+              ngModel.$setValidity('required', false);
             }
-            return isValid ? value : undefined;
+            return isValid ? value : allowInvalid(value, undefined);
           }
 
           var linkOptions = {};
@@ -119,11 +128,11 @@ angular.module('ui.mask', [])
           scope.$watch(iAttrs.ngModel, function(val) {
             if(modelViewValue && val) {
               var model = $parse(iAttrs.ngModel);
-              model.assign(scope, controller.$viewValue);
+              model.assign(scope, ngModel.$viewValue);
             }
           });
-          controller.$formatters.push(formatter);
-          controller.$parsers.push(parser);
+          ngModel.$formatters.push(formatter);
+          ngModel.$parsers.push(parser);
 
           function uninitialize(){
             maskProcessed = false;
@@ -141,13 +150,13 @@ angular.module('ui.mask', [])
               iElement.removeAttr('maxlength');
             }
 
-            iElement.val(controller.$modelValue);
-            controller.$viewValue = controller.$modelValue;
+            iElement.val(ngModel.$modelValue);
+            ngModel.$viewValue = ngModel.$modelValue;
             return false;
           }
 
           function initializeElement(){
-            value = oldValueUnmasked = unmaskValue(controller.$modelValue || '');
+            value = oldValueUnmasked = unmaskValue(ngModel.$modelValue || '');
             valueMasked = oldValue = maskValue(value);
             isValid = validateValue(value);
             var viewValue = isValid && value.length ? valueMasked : '';
@@ -156,7 +165,7 @@ angular.module('ui.mask', [])
             }
             iElement.attr('placeholder', maskPlaceholder);
             iElement.val(viewValue);
-            controller.$viewValue = viewValue;
+            ngModel.$viewValue = viewValue;
             // Not using $setViewValue so we don't clobber the model value and dirty the form
             // without any kind of user interaction.
           }
@@ -289,13 +298,17 @@ angular.module('ui.mask', [])
           }
 
           function blurHandler(){
+            if (ngModelOptions && ngModelOptions.$options && ngModelOptions.$options.allowInvalid === true) {
+              return;
+            }
             oldCaretPosition = 0;
             oldSelectionLength = 0;
+
             if (!isValid || value.length === 0) {
               valueMasked = '';
               iElement.val('');
               scope.$apply(function (){
-                controller.$setViewValue('');
+                ngModel.$setViewValue('');
               });
             }
           }
@@ -393,7 +406,7 @@ angular.module('ui.mask', [])
             if (valAltered) {
               // We've altered the raw value after it's been $digest'ed, we need to $apply the new value.
               scope.$apply(function (){
-                controller.$setViewValue(valUnmasked);
+                ngModel.$setViewValue(valUnmasked);
               });
             }
 

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -245,6 +245,13 @@ describe("uiMask", function () {
       input.triggerHandler("blur");
       expect(input.controller("ngModel").$modelValue).toBe("1 1 1");
       expect(input.controller("ngModel").$viewValue).toBe("");
+      scope.$apply(function(){
+        scope.x = "a a";
+        scope.mask = "(A) * 9";
+      });
+      input.triggerHandler("blur");
+      expect(input.controller("ngModel").$modelValue).toBe("a a");
+      expect(input.controller("ngModel").$viewValue).toBe("(a) a _");
     });
 
   });

--- a/modules/mask/test/maskSpec.js
+++ b/modules/mask/test/maskSpec.js
@@ -7,7 +7,7 @@ describe("uiMask", function () {
 
   beforeEach(module("ui.mask"));
   beforeEach(inject(function ($rootScope, $compile, uiMaskConfig) {
-    scope = $rootScope;
+    scope = $rootScope.$new();
     config = uiMaskConfig;
     compileElement = function(html) {
       return $compile(html)(scope);
@@ -18,44 +18,66 @@ describe("uiMask", function () {
 
     it("should not not happen if the mask is undefined or invalid", function() {
       var input = compileElement(inputHtml);
-      scope.$apply("x = 'abc123'");
+      scope.$apply(function(){
+        scope.x = "abc123";
+      });
       expect(input.val()).toBe("abc123");
-      scope.$apply("mask = '()_abc123'");
+      scope.$apply(function(){
+        scope.mask = "()_abc123";
+      });
       expect(input.val()).toBe("abc123");
     });
 
     it("should mask the value only if it's valid", function() {
       var input = compileElement(inputHtml);
-      scope.$apply("x = 'abc123'");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "abc123";
+        scope.mask = "(A) * 9";
+      });
       expect(input.val()).toBe("(a) b 1");
-      scope.$apply("mask = '(A) * 9 A'");
+      scope.$apply(function(){
+        scope.mask = "(A) * 9 A";
+      });
       expect(input.val()).toBe("");
     });
 
     it("should not dirty or invalidate the input", function() {
       var input = compileElement(inputHtml);
-      scope.$apply("x = 'abc123'");
-      scope.$apply("mask = '(9) * A'");
-      expect(input.hasClass("ng-pristine ng-valid")).toBeTruthy();
-      scope.$apply("mask = '(9) * A 9'");
-      expect(input.hasClass("ng-pristine ng-valid")).toBeTruthy();
+      scope.$apply(function(){
+        scope.x = "abc123";
+        scope.mask = "(9) * A";
+      });
+      expect(input.hasClass("ng-pristine")).toBeTruthy();
+      expect(input.hasClass("ng-valid")).toBeTruthy();
+      scope.$apply(function(){
+        scope.mask = "(9) * A 9";
+      });
+      expect(input.hasClass("ng-pristine")).toBeTruthy();
+      expect(input.hasClass("ng-valid")).toBeTruthy();
     });
 
     it("should not change the model value", function() {
-      scope.$apply("x = 'abc123'");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "abc123";
+        scope.mask = "(A) * 9";
+      });
       expect(scope.x).toBe("abc123");
-      scope.$apply("mask = '(A) * 9 A'");
+      scope.$apply(function(){
+        scope.mask = "(A) * 9 A";
+      });
       expect(scope.x).toBe("abc123");
     });
 
     it("should set ngModelController.$viewValue to match input value", function() {
       compileElement(formHtml);
-      scope.$apply("x = 'abc123'");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "abc123";
+        scope.mask = "(A) * 9";
+      });
       expect(scope.test.input.$viewValue).toBe("(a) b 1");
-      scope.$apply("mask = '(A) * 9 A'");
+      scope.$apply(function(){
+        scope.mask = "(A) * 9 A";
+      });
       expect(scope.test.input.$viewValue).toBe("");
     });
 
@@ -65,8 +87,10 @@ describe("uiMask", function () {
     it("should mask-as-you-type", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+      });
       input.val("a").triggerHandler("input");
       expect(input.val()).toBe("(a) _ _");
       input.val("ab").triggerHandler("input");
@@ -78,8 +102,10 @@ describe("uiMask", function () {
     it("should set ngModelController.$viewValue to match input value", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+      });
       input.val("a").triggerHandler("input");
       input.triggerHandler("change"); // Because IE8 and below are terrible
       expect(scope.test.input.$viewValue).toBe("(a) _ _");
@@ -88,8 +114,10 @@ describe("uiMask", function () {
     it("should parse unmasked value to model", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+      });
       input.val("abc123").triggerHandler("input");
       input.triggerHandler("change"); // Because IE8 and below are terrible
       expect(scope.x).toBe("ab1");
@@ -98,8 +126,10 @@ describe("uiMask", function () {
     it("should set model to undefined if masked value is invalid", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+      });
       input.val("a").triggerHandler("input");
       input.triggerHandler("change"); // Because IE8 and below are terrible
       expect(scope.x).toBeUndefined();
@@ -108,65 +138,125 @@ describe("uiMask", function () {
     it("should not set model to an empty mask", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+      });
       input.triggerHandler("input");
       expect(scope.x).toBe("");
     });
 
     it("should not setValidity on required to false on a control that isn't required", function() {
-      var input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}'>");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
-      scope.$apply("required = true");
-      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      var
+        input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}'>"),
+        ngModel = input.data("$ngModelController");
+
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+        scope.required = true;
+      });
+      expect(ngModel.$error.required).toBeUndefined();
       input.triggerHandler("input");
       expect(scope.x).toBe("");
-      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      expect(ngModel.$error.required).toBeUndefined();
 
       input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}' required>");
-      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      expect(ngModel.$error.required).toBeUndefined();
       input.triggerHandler("input");
-      expect(input.data("$ngModelController").$error.required).toBe(true);
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(true);
+      }
       input.val("abc123").triggerHandler("input");
       expect(scope.x).toBe("ab1");
-      expect(input.data("$ngModelController").$error.required).toBe(false);
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(false);
+      }
 
       input = compileElement("<input name='input' ng-model='x' ui-mask='{{mask}}' ng-required='required'>");
-      expect(input.data("$ngModelController").$error.required).toBeUndefined();
+      expect(ngModel.$error.required).toBeUndefined();
       input.triggerHandler("input");
-      expect(input.data("$ngModelController").$error.required).toBe(true);
-      scope.$apply("required = false");
-      expect(input.data("$ngModelController").$error.required).toBe(false);
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(true);
+      }
+      scope.$apply(function(){
+        scope.required = false;
+      });
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(false);
+      }
       input.triggerHandler("input");
-      expect(input.data("$ngModelController").$error.required).toBe(false);
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(false);
+      }
       input.triggerHandler("focus");
       input.triggerHandler("blur");
-      expect(input.data("$ngModelController").$error.required).toBe(false);
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(false);
+      }
       input.val("").triggerHandler("input");
-      expect(input.data("$ngModelController").$error.required).toBe(false);
+      if (ngModel.$$success) {
+        expect(ngModel.$error.required).toBeUndefined();
+      } else {
+        expect(ngModel.$error.required).toBe(false);
+      }
     });
   });
 
   describe("changes from the model", function () {
     it("should set the correct ngModelController.$viewValue", function() {
       compileElement(formHtml);
-      scope.$apply("mask = '(A) * 9'");
-      scope.$apply("x = ''");
-      expect(scope.test.input.$viewValue).not.toBeDefined();
-      scope.$apply("x = 'abc'");
-      expect(scope.test.input.$viewValue).not.toBeDefined();
-      scope.$apply("x = 'abc123'");
+      scope.$apply(function(){
+        scope.mask = "(A) * 9";
+        scope.x = "";
+      });
+      expect(scope.test.input.$viewValue).toBe("");
+      scope.$apply(function(){
+        scope.x = "abc";
+      });
+      expect(scope.test.input.$viewValue).toBeUndefined();
+      scope.$apply(function(){
+        scope.x = "abc123";
+      });
       expect(scope.test.input.$viewValue).toBe("(a) b 1");
     });
+  });
+
+  describe("ngModelOptions", function(){
+
+    it("allows invalid when option is set", function(){
+      var input = compileElement("<input ng-model-options='{allowInvalid: true}' ui-mask='{{mask}}' ng-model='x'>");
+      scope.$apply(function(){
+        scope.x = "1 1 1";
+        scope.mask = "(A) * 9";
+      });
+      input.triggerHandler("blur");
+      expect(input.controller("ngModel").$modelValue).toBe("1 1 1");
+      expect(input.controller("ngModel").$viewValue).toBe("");
+    });
+
   });
 
   describe("default mask definitions", function () {
     it("should accept optional mask after '?'", function (){
       var input = compileElement(inputHtml);
 
-      scope.$apply("x = ''");
-      scope.$apply("mask = '**?9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "**?9";
+      });
 
       input.val("aa").triggerHandler("input");
       input.triggerHandler("blur");
@@ -186,8 +276,10 @@ describe("uiMask", function () {
     it("should have default placeholder functionality", function() {
       var input = compileElement(inputHtml);
 
-      scope.$apply("x = ''");
-      scope.$apply("mask = '99/99/9999'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "99/99/9999";
+      });
 
       expect(input.attr("placeholder")).toBe("__/__/____");
     });
@@ -197,8 +289,10 @@ describe("uiMask", function () {
       var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' placeholder='MM/DD/YYYY'>",
           input           = compileElement(placeholderHtml);
 
-      scope.$apply("x = ''");
-      scope.$apply("mask = '99/99/9999'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "99/99/9999";
+      });
 
       expect(input.attr("placeholder")).toBe("MM/DD/YYYY");
 
@@ -212,15 +306,19 @@ describe("uiMask", function () {
       var placeholderHtml = "<input name='input' ng-model='x' ui-mask='{{mask}}' placeholder='{{placeholder}}'>",
           input           = compileElement(placeholderHtml);
 
-      scope.$apply("x = ''");
-      scope.$apply("mask = '99/99/9999'");
-      scope.$apply("placeholder = 'DD/MM/YYYY'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "99/99/9999";
+        scope.placeholder = "DD/MM/YYYY";
+      });
       expect(input.attr("placeholder")).toBe("DD/MM/YYYY");
 
       input.val("12").triggerHandler("input");
       expect(input.val()).toBe("12/MM/YYYY");
 
-      scope.$apply("placeholder = 'MM/DD/YYYY'");
+      scope.$apply(function(){
+        scope.placeholder = "MM/DD/YYYY";
+      });
       expect(input.val()).toBe("12/DD/YYYY");
 
       input.triggerHandler("blur");
@@ -236,8 +334,10 @@ describe("uiMask", function () {
 
       var input = compileElement(inputHtml);
 
-      scope.$apply("x = ''");
-      scope.$apply("mask = '@193'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "@193";
+      });
       input.val("f123").triggerHandler("input");
       input.triggerHandler("blur");
       expect(input.val()).toBe("f123");
@@ -251,8 +351,10 @@ describe("uiMask", function () {
       };
 
       var input = compileElement("<input type=\"text\" ng-model=\"x\" ui-mask=\"{{mask}}\" ui-options=\"input.options\">");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '@999'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "@999";
+      });
       input.val("f111").triggerHandler("input");
       input.triggerHandler("blur");
       expect(input.val()).toBe("f111");
@@ -262,8 +364,10 @@ describe("uiMask", function () {
   describe("blurring", function () {
     it("should clear an invalid value from the input", function() {
       var input = compileElement(inputHtml);
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(9) * A'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(9) * A";
+      });
       input.val("a").triggerHandler("input");
       input.triggerHandler("blur");
       expect(input.val()).toBe("");
@@ -272,8 +376,10 @@ describe("uiMask", function () {
     it("should clear an invalid value from the ngModelController.$viewValue", function() {
       var form  = compileElement(formHtml);
       var input = form.find("input");
-      scope.$apply("x = ''");
-      scope.$apply("mask = '(A) * 9'");
+      scope.$apply(function(){
+        scope.x = "";
+        scope.mask = "(A) * 9";
+      });
       input.val("a").triggerHandler("input");
       input.triggerHandler("blur");
       expect(scope.test.input.$viewValue).toBe("");

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -17,8 +17,8 @@ module.exports = function(config) {
       'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'modules/mask/*.js',
-      'modules/mask/test/*Spec.js'
+      'modules/*/*.js',
+      'modules/*/test/*Spec.js'
     ],
 
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -17,8 +17,8 @@ module.exports = function(config) {
       'bower_components/jquery/dist/jquery.js',
       'bower_components/angular/angular.js',
       'bower_components/angular-mocks/angular-mocks.js',
-      'modules/*/*.js',
-      'modules/*/test/*Spec.js'
+      'modules/mask/*.js',
+      'modules/mask/test/*Spec.js'
     ],
 
 


### PR DESCRIPTION
Tests are failing right now for 1.2 (but working on 1.3) because the ngMocks dependency is ancient (1.0.8), $error object in ngModel now aren't set to false/true anymore, but it doesn't exist when it's successiful, goes to the `$$success` object. 
