### PR TITLE
Fixes #248. Should fix most edge cases too.

### DIFF
--- a/modules/inflector/inflector.js
+++ b/modules/inflector/inflector.js
@@ -10,27 +10,30 @@
  *          {{ 'Here Is my_phoneNumber' | inflector:'variable' }} => hereIsMyPhoneNumber
  */
 angular.module('ui.inflector',[]).filter('inflector', function () {
-  function ucwords(text) {
-    return text.replace(/^([a-z])|\s+([a-z])/g, function ($1) {
-      return $1.toUpperCase();
-    });
+
+  function tokenize(text) {
+    text = text.replace(/([A-Z])|([\-|\_])/g, function(_, $1) { return ' ' + ($1 || ''); });
+    return text.replace(/\s\s+/g, ' ').trim().toLowerCase().split(' ');
   }
 
-  function breakup(text, separator) {
-    return text.replace(/[A-Z]/g, function (match) {
-      return separator + match;
+  function capitalizeTokens(tokens) {
+    var result = [];
+    angular.forEach(tokens, function(token) {
+      result.push(token.charAt(0).toUpperCase() + token.substr(1));
     });
+    return result;
   }
 
   var inflectors = {
     humanize: function (value) {
-      return ucwords(breakup(value, ' ').split('_').join(' '));
+      return capitalizeTokens(tokenize(value)).join(' ');
     },
     underscore: function (value) {
-      return value.substr(0, 1).toLowerCase() + breakup(value.substr(1), '_').toLowerCase().split(' ').join('_');
+      return tokenize(value).join('_');
     },
     variable: function (value) {
-      value = value.substr(0, 1).toLowerCase() + ucwords(value.split('_').join(' ')).substr(1).split(' ').join('');
+      value = tokenize(value);
+      value = value[0] + capitalizeTokens(value.slice(1)).join('');
       return value;
     }
   };

--- a/modules/inflector/test/inflectorSpec.js
+++ b/modules/inflector/test/inflectorSpec.js
@@ -23,13 +23,19 @@ describe('inflector', function () {
   describe('humanize', function () {
     it('should uppercase first letter and separate words with a space', function () {
       expect(inflectorFilter(testPhrase, 'humanize')).toEqual('Here Is My Phone Number');
+      expect(inflectorFilter('maya', 'humanize')).toEqual('Maya');
+      expect(inflectorFilter('bob Saget', 'humanize')).toEqual('Bob Saget');
+      expect(inflectorFilter('bob_ dole', 'humanize')).toEqual('Bob Dole');
+
     });
   });
+
   describe('underscore', function () {
     it('should lowercase everything and separate words with an underscore', function () {
       expect(inflectorFilter(testPhrase, 'underscore')).toEqual('here_is_my_phone_number');
     });
   });
+
   describe('variable', function () {
     it('should remove all separators and camelHump the phrase', function () {
       expect(inflectorFilter(testPhrase, 'variable')).toEqual('hereIsMyPhoneNumber');


### PR DESCRIPTION
Fixes #248 

Basically, I'm converting the input to a list of lowercase words.

When I get a capital letter, I add a space before it. When I get a `-` or `_` character, I replace it with a space. Then, I remove all the extra whitespace, make everything lowercase and split on the space character.

```
Here Is my_phoneNumber => ["here", "is", "my", "phone", "number"]
```

After that, the individual filters just work on the list of tokens.
