### PR TITLE
Updated highlight module to remove 'unsafe' from ng-html-bind

### DIFF
--- a/dist/ui-utils.js
+++ b/dist/ui-utils.js
@@ -100,22 +100,21 @@ angular.module('ui.format',[]).filter('format', function(){
  * @param search {string} needle to search for
  * @param [caseSensitive] {boolean} optional boolean to use case-sensitive searching
  */
-angular.module('ui.highlight',[]).filter('highlight', function () {
+angular.module('ui.highlight',[]).filter('highlight', [ '$sce' , function ($sce) {
   return function (text, search, caseSensitive) {
-    if (text && (search || angular.isNumber(search))) {
+    if (search || angular.isNumber(search)) {
       text = text.toString();
       search = search.toString();
       if (caseSensitive) {
-        return text.split(search).join('<span class="ui-match">' + search + '</span>');
+        return $sce.trustAsHtml(text.split(search).join('<span class="ui-match">' + search + '</span>'));
       } else {
-        return text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>');
+        return $sce.trustAsHtml(text.replace(new RegExp(search, 'gi'), '<span class="ui-match">$&</span>'));
       }
     } else {
-      return text;
+      return $sce.trustAsHtml(text);
     }
   };
-});
-
+}]);
 'use strict';
 
 // modeled after: angular-1.0.7/src/ng/directive/ngInclude.js

--- a/index.html
+++ b/index.html
@@ -228,14 +228,14 @@ $scope.tokens = { name:&#39;Bob&#39;, subject:&#39;wife&#39; };
 
     <p><input placeholder="Enter some text to highlight" ng-model="highlightText"></p>
 
-    <p ng-bind-html-unsafe="'Hello there, how are you today? I\'m fine thank you.' | highlight:highlightText:caseSensitive"></p>
+    <p ng-bind-html="'Hello there, how are you today? I\'m fine thank you.' | highlight:highlightText:caseSensitive"></p>
   </div>
 
   <h3>How?</h3>
 <pre class="prettyprint">
 &lt;label&gt;&lt;input type=&quot;checkbox&quot; ng-model=&quot;caseSensitive&quot;&gt; Case Sensitive?&lt;/label&gt;
 &lt;input placeholder=&quot;Enter some text to highlight&quot; value=&quot;you&quot; ng-model=&quot;highlightText&quot;&gt;
-&lt;p ng-bind-html-unsafe=&quot;&#x27;Hello there, how are you today? I\'m fine thank you.&#x27; | highlight:highlightText:caseSensitive&quot;&gt;&lt;/p&gt;
+&lt;p ng-bind-html=&quot;&#x27;Hello there, how are you today? I\'m fine thank you.&#x27; | highlight:highlightText:caseSensitive&quot;&gt;&lt;/p&gt;
 
 &lt;style&gt;
 .ui-match { background: yellow; }
@@ -1065,7 +1065,8 @@ Bar rule passes: {{!!myForm.myInput.$error.bar}}
 
 <script src="assets/vendor/prettify.js"></script>
 
-<script src="assets/vendor/angular.min.js"></script>
+<!--<script src="assets/vendor/angular.min.js"></script>-->
+<script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.28/angular.min.js"></script>script>
 <script src="core/prettifyDirective.js"></script>
 <script src="core/plunker.js"></script>
 


### PR DESCRIPTION
Relates to:
https://github.com/angular-ui/ui-utils/issues/174
https://github.com/angular-ui/ui-utils/pull/332
https://github.com/angular-ui/ui-utils/pull/333
https://github.com/angular-ui/ui-utils/pull/278
https://github.com/angular-ui/ui-utils/pull/277

You can test highlight here here:
http://f1lt3r.github.io/ui-utils/

Should look like this:
![screen shot 2014-12-18 at 2 14 31 pm](https://cloud.githubusercontent.com/assets/1218446/5494233/3c56c6e2-86c0-11e4-8f54-1c61c91e9bbe.png)
