### PR TITLE
bower path is angular-ui-utils, even for specific modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ This will copy the UI.Utils files into a `bower_components` folder, along with i
 <script type="text/javascript" src="bower_components/angular-ui-utils/ui-utils.js"></script>
 
 <!-- or just specific one-->
-<script type="text/javascript" src="bower_components/angular-ui-event/event.js"></script>
-<script type="text/javascript" src="bower_components/angular-ui-keypress/keypress.js"></script>
+<script type="text/javascript" src="bower_components/angular-ui-utils/event.js"></script>
+<script type="text/javascript" src="bower_components/angular-ui-utils/keypress.js"></script>
 <!-- ... -->
 ```
 


### PR DESCRIPTION
I just tested this with 'bower install angular-ui-utils#bower-highlight', #bower-event, and #bower-keypress, and all install to /bower_components/angular-ui-utils rather than the /angular-ui-[module] referenced in the readme.
