### PR TITLE
Add missing "main" attribute to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "grunt-ngmin": "0.0.3"
   },
   "scripts": {},
+  "main": "./modules/utils.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/angular-ui/ui-utils.git"


### PR DESCRIPTION
package.json requires a "main" attribute so that anything requiring the module will be able to find the main js file.  The major use case for this is browserify.
