### PR TITLE
Fix for #349 - ui-mask not properly invalidated when using clearOnBlur

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -293,9 +293,7 @@ angular.module('ui.mask', [])
             if (linkOptions.clearOnBlur) {
               oldCaretPosition = 0;
               oldSelectionLength = 0;
-            }
-            if (!isValid || value.length === 0) {
-              if (linkOptions.clearOnBlur) {
+              if (!isValid || value.length === 0) {
                 valueMasked = '';
                 iElement.val('');
                 scope.$apply(function () {

--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -298,10 +298,10 @@ angular.module('ui.mask', [])
               if (linkOptions.clearOnBlur) {
                 valueMasked = '';
                 iElement.val('');
+                scope.$apply(function () {
+                  controller.$setViewValue('');
+                });
               }
-              scope.$apply(function (){
-                controller.$setViewValue('');
-              });
             }
           }
 


### PR DESCRIPTION
A simple mispositioned curly brace was causing setViewValue('') to be called even when clearOnBlur was false. This triggered the parsers again, which can lead to incorrect validation.

This should fix #349.