### PR TITLE
Placeholder Override

### DIFF
--- a/modules/mask/mask.js
+++ b/modules/mask/mask.js
@@ -110,7 +110,11 @@ angular.module('ui.mask', [])
           }
 
           iAttrs.$observe('uiMask', initialize);
-          iAttrs.$observe('placeholder', initPlaceholder);
+          if (iAttrs.uiMaskPlaceholder) {
+            iAttrs.$observe('uiMaskPlaceholder', initPlaceholder);
+          } else {
+            iAttrs.$observe('placeholder', initPlaceholder);
+          }
           var modelViewValue = false;
           iAttrs.$observe('modelViewValue', function(val) {
             if(val === 'true') {
@@ -155,7 +159,9 @@ angular.module('ui.mask', [])
             if (iAttrs.maxlength) { // Double maxlength to allow pasting new val at end of mask
               iElement.attr('maxlength', maskCaretMap[maskCaretMap.length - 1] * 2);
             }
-            iElement.attr('placeholder', maskPlaceholder);
+            if (!iAttrs.uiMaskPlaceholder) {
+              iElement.attr('placeholder', maskPlaceholder);
+            }
             iElement.val(viewValue);
             controller.$viewValue = viewValue;
             // Not using $setViewValue so we don't clobber the model value and dirty the form
@@ -226,7 +232,7 @@ angular.module('ui.mask', [])
           }
 
           function getPlaceholderChar(i) {
-            var placeholder = iAttrs.placeholder;
+            var placeholder = iAttrs.uiMaskPlaceholder ? iAttrs.uiMaskPlaceholder : iAttrs.placeholder;
 
             if (typeof placeholder !== 'undefined' && placeholder[i]) {
               return placeholder[i];


### PR DESCRIPTION
Adds a uiMaskPlaceholder attribute which will be used instead of the HTML placeholder, when the field has focus.

This is useful for situations where the "main" placeholder is meant to be the input label. It allows the label placeholder to stay, then swaps to the mask placeholder on focus.
