### PR TITLE
Ui.scroll v1.1.0

### DIFF
--- a/modules/scroll/README.md
+++ b/modules/scroll/README.md
@@ -71,10 +71,14 @@ dl as a repeated tag is not supported.
 * **buffer-size - value**, optional - number of items requested from the datasource in a single request. The default is 10 and the minimal value is 3
 * **padding - value**, optional - extra height added to the visible area for the purpose of determining when the items should be created/destroyed.
 The value is relative to the visible height of the area, the default is 0.5 and the minimal value is 0.3
-* **is-loading - name**, optional - if provided a boolean value indicating whether there are any pending load requests will be placed in the member with the said name on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope
-* **top-visible - name**, optional - if provided a reference to the item currently in the topmost visible position will be placed in the member with the said name on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope
-* **top-visible-element - name**, optional - if provided a reference to the DOM element currently in the topmost visible position will be placed in the member with the said name on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope
-* **top-visible-scope - name**, optional - if provided a reference to the scope created for the item currently in the topmost visible position will be placed in the member with the said name on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope
+* **adapter - name**, optional - if provided a reference to the adapter object for the scroller instance will be placed in the member with the said name on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope. The adapter is a collection of methods and properties to manipulate and assess the scroller the adapter was created for.
+
+Some of the properties offered by the adapter can also be accessed directly from the directive by using matching attributes. In the same way as for the adapter attribute syntax for such attributes allows for providing a name under which the appropariate value will be placed on the scope associated with the viewport. If the viewport is the window, the value will be placed on the $rootScope. Below is a list of such attributes:
+
+* **is-loading - name**, optional - a boolean value indicating whether there are any pending load requests will be placed in the member with the said name. See also `isLoading` adapter property.
+* **top-visible - name**, optional - a reference to the item currently in the topmost visible position will be placed in the member with the said name. See also `topVisible` adapter property.
+* **top-visible-element - name**, optional - a reference to the DOM element currently in the topmost visible position will be placed in the member with the said name. See also `topVisibleElement` adapter property.
+* **top-visible-scope - name**, optional - a reference to the scope created for the item currently in the topmost visible position will be placed in the member with the said name. See also `topVisibleScope` adapter property.
 
 ###Data Source 
 Data source is an object to be used by the uiScroll directive to access the data. 
@@ -116,6 +120,36 @@ exactly `count` elements unless it hit eof/bof
     #### Description
     this is an optional method. If supplied the scroller will $watch its value and will refresh the content if the value has changed
 
+###Adapter
+Adapter object is a collection of methods and properties to be used to assess and manipulate the scroller instance adapater is created for. Adapter based API replaces old (undocumented) event based API introduced earlier for this purpose. The event based API is now deprecated but will remain available for backwards compatibililty purposes.
+
+####Manipulating the scroller content with applyUpdates method
+
+Method `applyUpdates` provides a way to update the scroller content without full reload of the content from the datasource. The updates are performed by changing the items in the scroller internal buffer after they are loaded from the datasource. An item in the buffer can be deleted or modified. Also several items can be inserted to replace a given item.
+
+* Method `applyUpdates(index, newItems)`
+
+    #### Description
+    Updates scroller content at the given location in the dataset
+#### Parameters
+    * **index** index of the item to be affected in the dataset.
+    * **newItems** an array of items to replace the affected item. If the array is empty (`[]`) the item will be deleted, otherwise the items in the array replace the affected item.
+
+* Method `applyUpdates(updater)`
+
+    #### Description
+    Updates scroller content as determined by the updater function
+#### Parameters
+    * **updater** a function to be applied to every item currently in the buffer. The function will recieve 3 parameters: `item`, `scope`, and `element`. Here `item` is the item to be affected, `scope` is the item $scope, and `element` is the html element for the item. The return value of the function should be an array of items. Similarly to the `newItem` parameter (see above), if the array is empty(`[]`), the item is deleted, otherwise the item is replaced by the items in the array. If the return value is not an array, the item remains unaffected, unless some updates were made to the item in the updater function. This can be thought of as in place update. 
+
+**Important:** Keep in mind that the modifications made by the `applyUpdates` methods are only applied to the content of the buffer. As the items in response to scrolling are pushed out of the buffer, the modifications are lost. It is your responsibility to ensure that as the scroller is scrolled back and a modified item is requested from the datasource again the values returned by the datasource would reflect the updated state. In other words you have to make sure that in addition to manipulating the scroller content you also apply the modifications to the dataset underlying the datasource.
+
+####Adapter properties
+
+* `isLoading` - a boolean value indicating whether there are any pending load requests.
+* `topVisible` - a reference to the item currently in the topmost visible position.
+* `topVisibleElement` - a reference to the DOM element currently in the topmost visible position.
+* `topVisibleScope` - a reference to the scope created for the item currently in the topmost visible position.
 
 uiScrollViewport directive
 -------------------
@@ -153,6 +187,18 @@ Once the first breakpoint set up this way is hit, the rest of them will work jus
 Do not ask me why this woodoo is necessary, but as of Chrome version 30 it is just the way it is.
 
 ###History
+
+####v1.1.0
+* Introduced API to dynamically update scroller content.
+* Deep 'name' properties access via dot-notation in template.
+* Fixed the problem occuring if the scroller is $destroyed while there are requests pending: [#64](https://github.com/Hill30/NGScroller/issues/64).
+
+####v1.0.3
+* Fixed memory leak on scroller destroy: [#63](https://github.com/Hill30/NGScroller/issues/63).
+* Removed examples from bower download list.
+
+####v1.0.2
+* Registration of ui-scroll in bower.
 
 ####v1.0.1
 * Deep datasource access via dot-notation in template. 

--- a/modules/scroll/test/ScrollerSpec.js
+++ b/modules/scroll/test/ScrollerSpec.js
@@ -1,69 +1,69 @@
 /*global describe, beforeEach, module, inject, it, spyOn, expect, $ */
 describe('uiScroll', function () {
-    'use strict';
+	'use strict';
 
-    angular.module('ui.scroll.test', [])
-        .factory('myEmptyDatasource', [
-            '$log', '$timeout', '$rootScope', function() {
-                return {
-                    get: function(index, count, success) {
-                        success([]);
-                    }
-                };
-            }
-        ])
-
-        .factory('myOnePageDatasource', [
-            '$log', '$timeout', '$rootScope', function() {
-                return {
-                    get: function(index, count, success) {
-                        if (index === 1) {
-                            success(['one', 'two', 'three']);
-                        } else {
-                            success([]);
-                        }
-                    }
-                };
-            }
-        ])
-
-        .factory('myMultipageDatasource', [
-            '$log', '$timeout', '$rootScope', function() {
-                return {
-                    get: function(index, count, success) {
-                        var result = [];
-                        for (var i = index; i<index+count; i++) {
-                            if (i>0 && i<=20)
-                                result.push('item' + i);
-                        }
-                        success(result);
-                    }
-                };
-            }
-        ])
-
-		.factory('AnotherDatasource', [
-			'$log', '$timeout', '$rootScope', function() {
+	angular.module('ui.scroll.test', [])
+		.factory('myEmptyDatasource', [
+			'$log', '$timeout', '$rootScope', function () {
 				return {
-					get: function(index, count, success) {
-                        var result = [];
-                        for (var i = index; i<index+count; i++) {
-                            if (i>-3 && i<1)
-                                result.push('item' + i);
-                        }
-                        success(result);
-                    }
+					get: function (index, count, success) {
+						success([]);
+					}
+				};
+			}
+		])
+
+		.factory('myOnePageDatasource', [
+			'$log', '$timeout', '$rootScope', function () {
+				return {
+					get: function (index, count, success) {
+						if (index === 1) {
+							success(['one', 'two', 'three']);
+						} else {
+							success([]);
+						}
+					}
+				};
+			}
+		])
+
+		.factory('myMultipageDatasource', [
+			'$log', '$timeout', '$rootScope', function () {
+				return {
+					get: function (index, count, success) {
+						var result = [];
+						for (var i = index; i < index + count; i++) {
+							if (i > 0 && i <= 20)
+								result.push('item' + i);
+						}
+						success(result);
+					}
+				};
+			}
+		])
+
+		.factory('anotherDatasource', [
+			'$log', '$timeout', '$rootScope', function () {
+				return {
+					get: function (index, count, success) {
+						var result = [];
+						for (var i = index; i < index + count; i++) {
+							if (i > -3 && i < 1)
+								result.push('item' + i);
+						}
+						success(result);
+					}
 				};
 			}
 		])
 
 		.factory('myEdgeDatasource', [
-			'$log', '$timeout', '$rootScope', function() {
+			'$log', '$timeout', '$rootScope', function () {
 				return {
-					get: function(index, count, success) {
+					get: function (index, count, success) {
 						var result = [];
-						for (var i = index; i<index+count; i++) {
-							if (i>-6 && i<=6)
+						for (var i = index; i < index + count; i++) {
+							if (i > -6 && i <= 6)
 								result.push('item' + i);
 						}
 						success(result);
@@ -73,12 +73,12 @@ describe('uiScroll', function () {
 		])
 
 		.factory('myDatasourceToPreventScrollBubbling', [
-			'$log', '$timeout', '$rootScope', function() {
+			'$log', '$timeout', '$rootScope', function () {
 				return {
-					get: function(index, count, success) {
+					get: function (index, count, success) {
 						var result = [];
-						for (var i = index; i<index+count; i++) {
-							if (i<-6 || i>20) {
+						for (var i = index; i < index + count; i++) {
+							if (i < -6 || i > 20) {
 								break;
 							}
 							result.push('item' + i);
@@ -89,100 +89,111 @@ describe('uiScroll', function () {
 			}
 		]);
 
-    beforeEach(module('ui.scroll'));
-    beforeEach(module('ui.scroll.test'));
+	beforeEach(module('ui.scroll'));
+	beforeEach(module('ui.scroll.test'));
 
-	var runTest = function(html, runTest, cleanupTest, options) {
-		inject(function($rootScope, $compile, $window, $timeout) {
-				var scroller = angular.element(html);
+	var createHtml = function (settings) {
+		var viewportStyle = ' style="height:' + (settings.viewportHeight || 200) + 'px"';
+		var itemStyle = settings.itemHeight ? ' style="height:' + settings.itemHeight + 'px"' : '';
+		var bufferSize = settings.bufferSize ? ' buffer-size="' + settings.bufferSize + '"' : '';
+		return '<div ui-scroll-viewport' + viewportStyle + '><div ui-scroll="item in ' + settings.datasource + '"' + itemStyle + bufferSize + '>{{$index}}: {{item}}</div></div>';
+	};
+
+	var runTest = function (scrollSettings, runTest, options) {
+		inject(function ($rootScope, $compile, $window, $timeout) {
+				var scroller = angular.element(createHtml(scrollSettings));
 				var scope = $rootScope.$new();
-				var sandbox = angular.element('<div/>');
-				angular.element(document).find('body').append(sandbox);
-				sandbox.append(scroller);
+				angular.element(document).find('body').append(scroller);
 
 				$compile(scroller)(scope);
 				scope.$apply();
 
-				if(!options || !options.noFlush) {
+				if (!options || !options.noFlush) {
 					$timeout.flush();
 				}
 
-				runTest($window, sandbox);
+				runTest(scroller);
 
-				sandbox.remove();
-				scope.$destroy();
+				scroller.remove();
 
-				if (cleanupTest) {
-					cleanupTest($window, scope);
+				if (options && typeof options.cleanupTest === 'function') {
+					if (options.flashOnCleanup) {
+						$timeout(function () {
+							options.cleanupTest(scroller, scope);
+						});
+					}
+					else {
+						options.cleanupTest(scroller, scope);
+					}
 				}
 			}
 		);
 	};
 
-	describe('basic setup', function() {
-			var html = '<div ui-scroll="item in myEmptyDatasource">{{$index}}: {{item}}</div>';
+	describe('basic setup', function () {
 
-				it('should bind to window scroll and resize events and unbind upon scope destroy', function(){
+			var scrollSettings = { datasource: 'myEmptyDatasource' };
+
+			it('should bind to window scroll and resize events and unbind them after the scope is destroyed', function () {
 				spyOn($.fn, 'bind').andCallThrough();
 				spyOn($.fn, 'unbind').andCallThrough();
-				runTest(html,
-					function($window) {
+				runTest(scrollSettings,
+					function (viewport) {
 						expect($.fn.bind.calls.length).toBe(3);
 						expect($.fn.bind.calls[0].args[0]).toBe('resize');
-						expect($.fn.bind.calls[0].object[0]).toBe($window);
+						expect($.fn.bind.calls[0].object[0]).toBe(viewport[0]);
 						expect($.fn.bind.calls[1].args[0]).toBe('scroll');
-						expect($.fn.bind.calls[1].object[0]).toBe($window);
+						expect($.fn.bind.calls[1].object[0]).toBe(viewport[0]);
 						expect($.fn.bind.calls[2].args[0]).toBe('mousewheel');
-						expect($.fn.bind.calls[2].object[0]).toBe($window);
-						expect($._data($window, 'events')).toBeDefined();
-					},
-					function($window) {
-						expect($.fn.unbind.calls.length).toBe(3);
-						expect($.fn.unbind.calls[0].args[0]).toBe('resize');
-						expect($.fn.unbind.calls[0].object[0]).toBe($window);
-						expect($.fn.unbind.calls[1].args[0]).toBe('scroll');
-						expect($.fn.unbind.calls[1].object[0]).toBe($window);
-						expect($.fn.unbind.calls[2].args[0]).toBe('mousewheel');
-						expect($.fn.unbind.calls[2].object[0]).toBe($window);
-					},
-					{
-						noFlush: true //empty data-set; nothing to render
+						expect($.fn.bind.calls[2].object[0]).toBe(viewport[0]);
+					}, {
+						noFlush: true, //empty data-set, nothing to render
+						flashOnCleanup: true,
+						cleanupTest: function (viewport) {
+							expect($.fn.unbind.calls.length).toBe(3);
+							expect($.fn.unbind.calls[0].args[0]).toBe('resize');
+							expect($.fn.unbind.calls[0].object[0]).toBe(viewport[0]);
+							expect($.fn.unbind.calls[1].args[0]).toBe('scroll');
+							expect($.fn.unbind.calls[1].object[0]).toBe(viewport[0]);
+							expect($.fn.unbind.calls[2].args[0]).toBe('mousewheel');
+							expect($.fn.unbind.calls[2].object[0]).toBe(viewport[0]);
+						}
 					}
 				);
 			});
 
-			it('should create 2 divs of 0 height', function() {
-				runTest(html,
-					function($window, sandbox) {
-						expect(sandbox.children().length).toBe(2);
+			it('should create 2 divs of 0 height', function () {
+				runTest(scrollSettings,
+					function (viewport) {
+						expect(viewport.children().length).toBe(2);
 
-						var topPadding = sandbox.children()[0];
+						var topPadding = viewport.children()[0];
 						expect(topPadding.tagName.toLowerCase()).toBe('div');
 						expect(angular.element(topPadding).css('height')).toBe('0px');
 
-						var bottomPadding = sandbox.children()[1];
+						var bottomPadding = viewport.children()[1];
 						expect(bottomPadding.tagName.toLowerCase()).toBe('div');
 						expect(angular.element(bottomPadding).css('height')).toBe('0px');
 
-					}, null, {
-						noFlush: true
+					}, {
+						noFlush: true //empty data-set, nothing to render
 					}
 				);
 			});
 
-			it('should call get on the datasource 1 time ', function() {
+			it('should call get on the datasource 1 time ', function () {
 				var spy;
-				inject(function(myEmptyDatasource){
+				inject(function (myEmptyDatasource) {
 					spy = spyOn(myEmptyDatasource, 'get').andCallThrough();
 				});
-				runTest(html,
-					function() {
+				runTest(scrollSettings,
+					function () {
 						expect(spy.calls.length).toBe(2);
 						expect(spy.calls[0].args[0]).toBe(1);
 						expect(spy.calls[1].args[0]).toBe(-9);
 
-					}, null, {
-						noFlush: true
+					}, {
+						noFlush: true //empty data-set, nothing to render
 					}
 				);
 			});
@@ -190,75 +201,74 @@ describe('uiScroll', function () {
 	);
 
 	describe('datasource with only 3 elements', function () {
+		var scrollSettings = { datasource: 'myOnePageDatasource' };
 
-		var html = '<div ui-scroll="item in myOnePageDatasource">{{$index}}: {{item}}</div>';
+		it('should create 3 divs with data (+ 2 padding divs)', function () {
+			runTest(scrollSettings,
+				function (viewport) {
+					expect(viewport.children().length).toBe(5);
 
-		it('should create 3 divs with data (+ 2 padding divs)', function() {
-			runTest(html,
-				function($window, sandbox) {
-					expect(sandbox.children().length).toBe(5);
-
-					var row1 = sandbox.children()[1];
+					var row1 = viewport.children()[1];
 					expect(row1.tagName.toLowerCase()).toBe('div');
 					expect(row1.innerHTML).toBe('1: one');
 
-					var row2 = sandbox.children()[2];
+					var row2 = viewport.children()[2];
 					expect(row2.tagName.toLowerCase()).toBe('div');
 					expect(row2.innerHTML).toBe('2: two');
 
-					var row3 = sandbox.children()[3];
+					var row3 = viewport.children()[3];
 					expect(row3.tagName.toLowerCase()).toBe('div');
 					expect(row3.innerHTML).toBe('3: three');
 				}
 			);
 		});
 
-		it('should call get on the datasource 2 times ', function() {
+		it('should call get on the datasource 2 times ', function () {
 			var spy;
-			inject(function(myOnePageDatasource){
+			inject(function (myOnePageDatasource) {
 				spy = spyOn(myOnePageDatasource, 'get').andCallThrough();
-			runTest(html,
-				function() {
-					expect(spy.calls.length).toBe(2);
+				runTest(scrollSettings,
+					function () {
+						expect(spy.calls.length).toBe(2);
 
-					expect(spy.calls[0].args[0]).toBe(1);  // gets 3 rows (with eof)
-					expect(spy.calls[1].args[0]).toBe(-9); // gets 0 rows (and bof)
-				});
+						expect(spy.calls[0].args[0]).toBe(1);  // gets 3 rows (with eof)
+						expect(spy.calls[1].args[0]).toBe(-9); // gets 0 rows (and bof)
+					});
 			});
 
 		});
 	});
 
 	describe('datasource with only 3 elements (negative index)', function () {
+		var scrollSettings = { datasource: 'anotherDatasource' };
 
-		var html = '<div ui-scroll="item in AnotherDatasource">{{$index}}: {{item}}</div>';
+		it('should create 3 divs with data (+ 2 padding divs)', function () {
+			runTest(scrollSettings,
+				function (viewport) {
+					expect(viewport.children().length).toBe(5);
 
-		it('should create 3 divs with data (+ 2 padding divs)', function() {
-			runTest(html,
-				function($window, sandbox) {
-					expect(sandbox.children().length).toBe(5);
-
-					var row1 = sandbox.children()[1];
+					var row1 = viewport.children()[1];
 					expect(row1.tagName.toLowerCase()).toBe('div');
 					expect(row1.innerHTML).toBe('-2: item-2');
 
-					var row2 = sandbox.children()[2];
+					var row2 = viewport.children()[2];
 					expect(row2.tagName.toLowerCase()).toBe('div');
 					expect(row2.innerHTML).toBe('-1: item-1');
 
-					var row3 = sandbox.children()[3];
+					var row3 = viewport.children()[3];
 					expect(row3.tagName.toLowerCase()).toBe('div');
 					expect(row3.innerHTML).toBe('0: item0');
 				}
 			);
 		});
 
-		it('should call get on the datasource 2 times ', function() {
+
+		it('should call get on the datasource 2 times ', function () {
 			var spy;
-			inject(function(AnotherDatasource){
-				spy = spyOn(AnotherDatasource, 'get').andCallThrough();
-				runTest(html,
-					function() {
+			inject(function (anotherDatasource) {
+				spy = spyOn(anotherDatasource, 'get').andCallThrough();
+				runTest(scrollSettings,
+					function () {
 						expect(spy.calls.length).toBe(2);
 
 						expect(spy.calls[0].args[0]).toBe(1);  // gets 0 rows (and eof)
@@ -270,20 +280,18 @@ describe('uiScroll', function () {
 	});
 
 	describe('datasource with 20 elements and buffer size 3 - constrained viewport', function () {
+		var scrollSettings = { datasource: 'myMultipageDatasource', itemHeight: 40, bufferSize: 3 };
 
-		var html = '<div ui-scroll-viewport style="height:200px"><div style="height:40px" ui-scroll="item in myMultipageDatasource" buffer-size="3">{{$index}}: {{item}}</div></div>';
+		it('should create 6 divs with data (+ 2 padding divs)', function () {
+			runTest(scrollSettings,
+				function (viewport) {
+					expect(viewport.children().length).toBe(8);
+					expect(viewport.scrollTop()).toBe(0);
+					expect(viewport.children().css('height')).toBe('0px');
+					expect(angular.element(viewport.children()[7]).css('height')).toBe('0px');
 
-		it('should create 6 divs with data (+ 2 padding divs)', function() {
-			runTest(html,
-				function($window, sandbox) {
-					var scroller = sandbox.children();
-					expect(scroller.children().length).toBe(8);
-					expect(scroller.scrollTop()).toBe(0);
-					expect(scroller.children().css('height')).toBe('0px');
-					expect(angular.element(scroller.children()[7]).css('height')).toBe('0px');
-
-					for (var i = 1; i< 7; i++) {
-						var row = scroller.children()[i];
+					for (var i = 1; i < 7; i++) {
+						var row = viewport.children()[i];
 						expect(row.tagName.toLowerCase()).toBe('div');
 						expect(row.innerHTML).toBe(i + ': item' + i);
 					}
@@ -292,13 +300,13 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should call get on the datasource 3 times ', function() {
+		it('should call get on the datasource 3 times ', function () {
 			var spy;
-			inject(function(myMultipageDatasource){
+			inject(function (myMultipageDatasource) {
 				spy = spyOn(myMultipageDatasource, 'get').andCallThrough();
 			});
-			runTest(html,
-				function() {
+			runTest(scrollSettings,
+				function () {
 					expect(spy.calls.length).toBe(3);
 
 					expect(spy.calls[0].args[0]).toBe(1);
@@ -309,21 +317,20 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should create 3 more divs (9 divs total) with data (+ 2 padding divs)', function() {
-			runTest(html,
-				function($window, sandbox) {
-					var scroller = sandbox.children();
-					scroller.scrollTop(100);
-					scroller.trigger('scroll');
-					inject(function($timeout){
+		it('should create 3 more divs (9 divs total) with data (+ 2 padding divs)', function () {
+			runTest(scrollSettings,
+				function (viewport) {
+					viewport.scrollTop(100);
+					viewport.trigger('scroll');
+					inject(function ($timeout) {
 						$timeout.flush();
-						expect(scroller.children().length).toBe(11);
-						expect(scroller.scrollTop()).toBe(40);
-						expect(scroller.children().css('height')).toBe('0px');
-						expect(angular.element(scroller.children()[10]).css('height')).toBe('0px');
+						expect(viewport.children().length).toBe(11);
+						expect(viewport.scrollTop()).toBe(40);
+						expect(viewport.children().css('height')).toBe('0px');
+						expect(angular.element(viewport.children()[10]).css('height')).toBe('0px');
 
-						for (var i = 1; i< 10; i++) {
-							var row = scroller.children()[i];
+						for (var i = 1; i < 10; i++) {
+							var row = viewport.children()[i];
 							expect(row.tagName.toLowerCase()).toBe('div');
 							expect(row.innerHTML).toBe(i + ': item' + i);
 						}
@@ -333,16 +340,15 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should call get on the datasource 1 extra time (4 total) ', function() {
+		it('should call get on the datasource 1 extra time (4 total) ', function () {
 			var spy;
-			inject(function(myMultipageDatasource){
+			inject(function (myMultipageDatasource) {
 				spy = spyOn(myMultipageDatasource, 'get').andCallThrough();
 			});
-			runTest(html,
-				function($window, sandbox) {
-					var scroller = sandbox.children();
-					scroller.scrollTop(100);
-					scroller.trigger('scroll');
+			runTest(scrollSettings,
+				function (viewport) {
+					viewport.scrollTop(100);
+					viewport.trigger('scroll');
 					expect(spy.calls.length).toBe(4);
 
 					expect(spy.calls[0].args[0]).toBe(1);
@@ -354,50 +360,52 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should clip 3 divs from the top and add 3 more divs to the bottom (9 divs total) (+ 2 padding divs)', function() {
-			runTest(html,
-				function($window, sandbox) {
+		it('should clip 3 divs from the top and add 3 more divs to the bottom (9 divs total) (+ 2 padding divs)', function () {
+			runTest(scrollSettings,
+				function (viewport) {
 					var flush;
-					inject(function($timeout){flush = $timeout.flush;});
-					var scroller = sandbox.children();
+					inject(function ($timeout) {
+						flush = $timeout.flush;
+					});
 
-					scroller.scrollTop(100);
-					scroller.trigger('scroll');
+					viewport.scrollTop(100);
+					viewport.trigger('scroll');
 					flush();
-					scroller.scrollTop(400);
-					scroller.trigger('scroll');
+					viewport.scrollTop(400);
+					viewport.trigger('scroll');
 					flush();
 
-					expect(scroller.children().length).toBe(11);
-					expect(scroller.scrollTop()).toBe(160);
-					expect(scroller.children().css('height')).toBe('120px');
-					expect(angular.element(scroller.children()[10]).css('height')).toBe('0px');
+					expect(viewport.children().length).toBe(11);
+					expect(viewport.scrollTop()).toBe(160);
+					expect(viewport.children().css('height')).toBe('120px');
+					expect(angular.element(viewport.children()[10]).css('height')).toBe('0px');
 
-					for (var i = 1; i< 10; i++) {
-						var row = scroller.children()[i];
+					for (var i = 1; i < 10; i++) {
+						var row = viewport.children()[i];
 						expect(row.tagName.toLowerCase()).toBe('div');
-						expect(row.innerHTML).toBe((i+3) + ': item' + (i+3));
+						expect(row.innerHTML).toBe((i + 3) + ': item' + (i + 3));
 					}
 
 				}
 			);
 		});
 
-		it('should call get on the datasource 1 more time (4 total) ', function() {
+		it('should call get on the datasource 1 more time (4 total) ', function () {
 			var flush;
-			inject(function($timeout){flush = $timeout.flush;});
+			inject(function ($timeout) {
+				flush = $timeout.flush;
+			});
 			var spy;
-			inject(function(myMultipageDatasource){
+			inject(function (myMultipageDatasource) {
 				spy = spyOn(myMultipageDatasource, 'get').andCallThrough();
 			});
-			runTest(html,
-				function($window, sandbox) {
-					var scroller = sandbox.children();
-					scroller.scrollTop(100);
-					scroller.trigger('scroll');
+			runTest(scrollSettings,
+				function (viewport) {
+					viewport.scrollTop(100);
+					viewport.trigger('scroll');
 					flush();
-					scroller.scrollTop(400);
-					scroller.trigger('scroll');
+					viewport.scrollTop(400);
+					viewport.trigger('scroll');
 					flush();
 
 					expect(spy.calls.length).toBe(5);
@@ -411,29 +419,30 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should re-add 3 divs at the top and clip 3 divs from the bottom (9 divs total) (+ 2 padding divs)', function() {
+		it('should re-add 3 divs at the top and clip 3 divs from the bottom (9 divs total) (+ 2 padding divs)', function () {
 			var flush;
-			inject(function($timeout){flush = $timeout.flush;});
-			runTest(html,
-				function($window, sandbox) {
-					var scroller = sandbox.children();
-					scroller.scrollTop(100);
-					scroller.trigger('scroll');
+			inject(function ($timeout) {
+				flush = $timeout.flush;
+			});
+			runTest(scrollSettings,
+				function (viewport) {
+					viewport.scrollTop(100);
+					viewport.trigger('scroll');
 					flush();
-					scroller.scrollTop(400);
-					scroller.trigger('scroll');
+					viewport.scrollTop(400);
+					viewport.trigger('scroll');
 					flush();
-					scroller.scrollTop(0);
-					scroller.trigger('scroll');
+					viewport.scrollTop(0);
+					viewport.trigger('scroll');
 					flush();
 
-					expect(scroller.children().length).toBe(8);
-					expect(scroller.scrollTop()).toBe(0);
-					expect(scroller.children().css('height')).toBe('0px');
-					expect(angular.element(scroller.children()[7]).css('height')).toBe('240px');
+					expect(viewport.children().length).toBe(8);
+					expect(viewport.scrollTop()).toBe(0);
+					expect(viewport.children().css('height')).toBe('0px');
+					expect(angular.element(viewport.children()[7]).css('height')).toBe('240px');
 
-					for (var i = 1; i< 7; i++) {
-						var row = scroller.children()[i];
+					for (var i = 1; i < 7; i++) {
+						var row = viewport.children()[i];
 						expect(row.tagName.toLowerCase()).toBe('div');
 						expect(row.innerHTML).toBe((i) + ': item' + (i));
 					}
@@ -442,24 +451,25 @@ describe('uiScroll', function () {
 			);
 		});
 
-		it('should call get on the datasource 1 more time (4 total) ', function() {
+		it('should call get on the datasource 1 more time (4 total) ', function () {
 			var spy;
-			inject(function(myMultipageDatasource){
+			inject(function (myMultipageDatasource) {
 				spy = spyOn(myMultipageDatasource, 'get').andCallThrough();
 			});
 			var flush;
-			inject(function($timeout){flush = $timeout.flush;});
-			runTest(html,
-				function($window, sandbox) {
-					var scroller = sandbox.children();
-					scroller.scrollTop(100);
-					scroller.trigger('scroll');
+			inject(function ($timeout) {
+				flush = $timeout.flush;
+			});
+			runTest(scrollSettings,
+				function (viewport) {
+					viewport.scrollTop(100);
+					viewport.trigger('scroll');
 					flush();
-					scroller.scrollTop(400);
-					scroller.trigger('scroll');
+					viewport.scrollTop(400);
+					viewport.trigger('scroll');
 					flush();
-					scroller.scrollTop(0);
-					scroller.trigger('scroll');
+					viewport.scrollTop(0);
+					viewport.trigger('scroll');
 					flush();
 					expect(spy.calls.length).toBe(7);
 
@@ -477,192 +487,211 @@ describe('uiScroll', function () {
 
 	});
 
-    describe('datasource with 12 elements and buffer size 3 (fold/edge cases)', function () {
+	describe('datasource with 12 elements and buffer size 3 (fold/edge cases)', function () {
 
-        var itemsCount = 12, buffer = 3, itemHeight = 20;
-        var makeHtml = function (viewportHeight) {
-            return '<div ui-scroll-viewport style="height:' + viewportHeight + 'px"><div style="height:' + itemHeight + 'px" ui-scroll="item in myEdgeDatasource" buffer-size="' + buffer + '">{{$index}}: {{item}}</div></div>';
-        };
+		var itemsCount = 12, buffer = 3, itemHeight = 20;
+		it('[full frame] should call get on the datasource 4 (12/3) times + 2 additional times (with empty result)', function () {
+			var spy;
+			var viewportHeight = itemsCount * itemHeight;
 
-        it('[full frame] should call get on the datasource 4 (12/3) times + 2 additional times (with empty result)', function() {
-            var spy;
-            var viewportHeight = itemsCount * itemHeight;
+			inject(function (myEdgeDatasource) {
+				spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+			});
 
-            inject(function(myEdgeDatasource){
-                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
-            });
+			runTest(
+				{
+					datasource: 'myEdgeDatasource',
+					bufferSize: buffer,
+					viewportHeight: viewportHeight,
+					itemHeight: itemHeight
+				},
+				function () {
+					expect(spy.calls.length).toBe(parseInt(itemsCount / buffer, 10) + 2);
 
-            runTest(makeHtml(viewportHeight),
-                function() {
-                    expect(spy.calls.length).toBe(parseInt(itemsCount/buffer, 10) + 2);
+					expect(spy.calls[0].args[0]).toBe(1);
+					expect(spy.calls[1].args[0]).toBe(4);
+					expect(spy.calls[2].args[0]).toBe(7);
+					expect(spy.calls[3].args[0]).toBe(-2);
+					expect(spy.calls[4].args[0]).toBe(-5);
+					expect(spy.calls[5].args[0]).toBe(-8);
+				}
+			);
+		});
 
-                    expect(spy.calls[0].args[0]).toBe(1);
-                    expect(spy.calls[1].args[0]).toBe(4);
-                    expect(spy.calls[2].args[0]).toBe(7);
-                    expect(spy.calls[3].args[0]).toBe(-2);
-                    expect(spy.calls[4].args[0]).toBe(-5);
-                    expect(spy.calls[5].args[0]).toBe(-8);
-                }
-            );
-        });
+		it('[fold frame] should call get on the datasource 3 times', function () {
+			var spy;
+			var viewportHeight = buffer * itemHeight;
 
-        it('[fold frame] should call get on the datasource 3 times', function() {
-            var spy;
-            var viewportHeight = buffer * itemHeight;
+			inject(function (myEdgeDatasource) {
+				spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+			});
 
-            inject(function(myEdgeDatasource){
-                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
-            });
+			runTest(
+				{
+					datasource: 'myEdgeDatasource',
+					bufferSize: buffer,
+					viewportHeight: viewportHeight,
+					itemHeight: itemHeight
+				},
+				function () {
+					expect(spy.calls.length).toBe(3);
 
-            runTest(makeHtml(viewportHeight),
-                function() {
-                    expect(spy.calls.length).toBe(3);
+					expect(spy.calls[0].args[0]).toBe(1);
+					expect(spy.calls[1].args[0]).toBe(4);
+					expect(spy.calls[2].args[0]).toBe(-2);
+				}
+			);
+		});
 
-                    expect(spy.calls[0].args[0]).toBe(1);
-                    expect(spy.calls[1].args[0]).toBe(4);
-                    expect(spy.calls[2].args[0]).toBe(-2);
-                }
-            );
-        });
+		it('[fold frame, scroll down] should call get on the datasource 1 extra time', function () {
+			var spy, flush;
+			var viewportHeight = buffer * itemHeight;
 
-        it('[fold frame, scroll down] should call get on the datasource 1 extra time', function() {
-            var spy, flush;
-            var viewportHeight = buffer * itemHeight;
+			inject(function (myEdgeDatasource) {
+				spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+			});
+			inject(function ($timeout) {
+				flush = $timeout.flush;
+			});
 
-            inject(function (myEdgeDatasource) {
-                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
-            });
-            inject(function ($timeout) {
-                flush = $timeout.flush;
-            });
+			runTest(
+				{
+					datasource: 'myEdgeDatasource',
+					bufferSize: buffer,
+					viewportHeight: viewportHeight,
+					itemHeight: itemHeight
+				},
+				function (viewport) {
+					viewport.scrollTop(viewportHeight + itemHeight);
+					viewport.trigger('scroll');
+					flush();
+					viewport.scrollTop(viewportHeight + itemHeight * 2);
+					viewport.trigger('scroll');
+					expect(flush).toThrow();
 
-            runTest(makeHtml(viewportHeight),
-                function($window, sandbox) {
-                    var scroller = sandbox.children();
-                    scroller.scrollTop(viewportHeight + itemHeight);
-                    scroller.trigger('scroll');
-                    flush();
-                    scroller.scrollTop(viewportHeight + itemHeight * 2);
-                    scroller.trigger('scroll');
-                    expect(flush).toThrow();
+					expect(spy.calls.length).toBe(4);
 
-                    expect(spy.calls.length).toBe(4);
+					expect(spy.calls[0].args[0]).toBe(1);
+					expect(spy.calls[1].args[0]).toBe(4); //last full
+					expect(spy.calls[2].args[0]).toBe(-2);
+					expect(spy.calls[3].args[0]).toBe(5); //empty
 
-                    expect(spy.calls[0].args[0]).toBe(1);
-                    expect(spy.calls[1].args[0]).toBe(4); //last full
-                    expect(spy.calls[2].args[0]).toBe(-2);
-                    expect(spy.calls[3].args[0]).toBe(5); //empty
+				}
+			);
+		});
 
-                }
-            );
-        });
+		it('[fold frame, scroll up] should call get on the datasource 2 extra times', function () {
+			var spy, flush;
+			var viewportHeight = buffer * itemHeight;
 
-        it('[fold frame, scroll up] should call get on the datasource 2 extra times', function() {
-            var spy, flush;
-            var viewportHeight = buffer * itemHeight;
+			inject(function (myEdgeDatasource) {
+				spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
+			});
+			inject(function ($timeout) {
+				flush = $timeout.flush;
+			});
 
-            inject(function (myEdgeDatasource) {
-                spy = spyOn(myEdgeDatasource, 'get').andCallThrough();
-            });
-            inject(function ($timeout) {
-                flush = $timeout.flush;
-            });
+			runTest(
+				{
+					datasource: 'myEdgeDatasource',
+					bufferSize: buffer,
+					viewportHeight: viewportHeight,
+					itemHeight: itemHeight
+				},
+				function (viewport) {
+					viewport.scrollTop(0); //first full, scroll to -2
+					viewport.trigger('scroll');
+					flush();
+					viewport.scrollTop(0); //last full, scroll to -5, bof is reached
+					viewport.trigger('scroll');
+					expect(flush).toThrow();
+					viewport.scrollTop(0); //empty, no scroll occured (-8)
+					viewport.trigger('scroll');
+					expect(flush).toThrow();
 
-            runTest(makeHtml(viewportHeight),
-                function($window, sandbox) {
-                    var scroller = sandbox.children();
-                    scroller.scrollTop(0); //first full, scroll to -2
-                    scroller.trigger('scroll');
-                    flush();
-                    scroller.scrollTop(0); //last full, scroll to -5, bof is reached
-                    scroller.trigger('scroll');
-                    expect(flush).toThrow();
-                    scroller.scrollTop(0); //empty, no scroll occured (-8)
-                    scroller.trigger('scroll');
-                    expect(flush).toThrow();
+					expect(spy.calls.length).toBe(5);
 
-                    expect(spy.calls.length).toBe(5);
+					expect(spy.calls[0].args[0]).toBe(1);
+					expect(spy.calls[1].args[0]).toBe(4);
+					expect(spy.calls[2].args[0]).toBe(-2); //first full
+					expect(spy.calls[3].args[0]).toBe(-5); //last full
+					expect(spy.calls[4].args[0]).toBe(-8); //empty
 
-                    expect(spy.calls[0].args[0]).toBe(1);
-                    expect(spy.calls[1].args[0]).toBe(4);
-                    expect(spy.calls[2].args[0]).toBe(-2); //first full
-                    expect(spy.calls[3].args[0]).toBe(-5); //last full
-                    expect(spy.calls[4].args[0]).toBe(-8); //empty
+				}
+			);
+		});
 
-                }
-            );
-        });
-
-    });
+	});
 
 
-    describe('prevent unwanted scroll bubbling', function () {
+	describe('prevent unwanted scroll bubbling', function () {
+		var scrollSettings = { datasource: 'myDatasourceToPreventScrollBubbling', bufferSize: 3, viewportHeight: 300 };
+		var documentScrollBubblingCount = 0;
 
-        var commonHtml = '<div ui-scroll-viewport style="width: 400px; height: 300px; display: block; background-color: white;"><ul><li ui-scroll="item in myDatasourceToPreventScrollBubbling" buffer-size="3">{{$index}}: {{item}}</li></ul></div>';
-        var documentScrollBubblingCount = 0;
-        var incrementDocumentScrollCount = function(event) {
-            event = event.originalEvent || event;
-            if(!event.defaultPrevented) {
-                documentScrollBubblingCount++;
-            }
-        };
-        var getNewWheelEvent = function () {
-            var event = document.createEvent('MouseEvents');
-            event.initEvent('mousewheel', true, true);
-            event.wheelDelta = 120;
-            return event;
-        };
+		var incrementDocumentScrollCount = function (event) {
+			event = event.originalEvent || event;
+			if (!event.defaultPrevented) {
+				documentScrollBubblingCount++;
+			}
+		};
+		var getNewWheelEvent = function () {
+			var event = document.createEvent('MouseEvents');
+			event.initEvent('mousewheel', true, true);
+			event.wheelDelta = 120;
+			return event;
+		};
 
-        it('should prevent wheel-event bubbling until bof is reached', function() {
-            var spy, flush;
+		it('should prevent wheel-event bubbling until bof is reached', function () {
+			var spy, flush;
 
-            inject(function (myDatasourceToPreventScrollBubbling) {
-                spy = spyOn(myDatasourceToPreventScrollBubbling, 'get').andCallThrough();
-            });
-            inject(function ($timeout) {
-                flush = $timeout.flush;
-            });
+			inject(function (myDatasourceToPreventScrollBubbling) {
+				spy = spyOn(myDatasourceToPreventScrollBubbling, 'get').andCallThrough();
+			});
+			inject(function ($timeout) {
+				flush = $timeout.flush;
+			});
 
-            runTest(commonHtml,
-                function($window, sandbox) {
-                    var scroller = sandbox.children();
-                    var wheelEventElement = scroller[0];
+			runTest(scrollSettings,
+				function (viewport) {
+					var wheelEventElement = viewport[0];
 
-                    angular.element(document.body).bind('mousewheel', incrementDocumentScrollCount); //spy for wheel-events bubbling
+					angular.element(document.body).bind('mousewheel', incrementDocumentScrollCount); //spy for wheel-events bubbling
 
-                    //simulate multiple wheel-scroll events within viewport
+					//simulate multiple wheel-scroll events within viewport
 
-                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred but document will not scroll because of viewport will be scrolled
-                    expect(documentScrollBubblingCount).toBe(1);
+					wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred but document will not scroll because of viewport will be scrolled
+					expect(documentScrollBubblingCount).toBe(1);
 
-                    scroller.scrollTop(0);
-                    scroller.trigger('scroll');
+					viewport.scrollTop(0);
+					viewport.trigger('scroll');
 
-                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //now we are at top but preventDefault will occur because of bof will be reached only after next scroll trigger
-                    expect(documentScrollBubblingCount).toBe(1); //here! the only one prevented wheel-event
+					wheelEventElement.dispatchEvent(getNewWheelEvent()); //now we are at top but preventDefault will occur because of bof will be reached only after next scroll trigger
+					expect(documentScrollBubblingCount).toBe(1); //here! the only one prevented wheel-event
 
-                    flush();
+					flush();
 
-                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred but document will not scroll because of viewport will be scrolled
-                    expect(documentScrollBubblingCount).toBe(2);
+					wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred but document will not scroll because of viewport will be scrolled
+					expect(documentScrollBubblingCount).toBe(2);
 
-                    scroller.scrollTop(0);
-                    scroller.trigger('scroll'); //bof will be reach here
+					viewport.scrollTop(0);
+					viewport.trigger('scroll'); //bof will be reach here
 
-                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred because we are at top and bof is reached
-                    expect(documentScrollBubblingCount).toBe(3);
+					wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred because we are at top and bof is reached
+					expect(documentScrollBubblingCount).toBe(3);
 
-                    expect(flush).toThrow(); //there is no new data, bof is reached
+					expect(flush).toThrow(); //there is no new data, bof is reached
 
-                    wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred because we are at top and bof is reached
-                    expect(documentScrollBubblingCount).toBe(4);
+					wheelEventElement.dispatchEvent(getNewWheelEvent()); //preventDefault will not occurred because we are at top and bof is reached
+					expect(documentScrollBubblingCount).toBe(4);
 
-                }, function() {
-                    angular.element(document.body).unbind('mousewheel', incrementDocumentScrollCount);
-                }
-            );
+				}, {
+					cleanupTest: function () {
+						angular.element(document.body).unbind('mousewheel', incrementDocumentScrollCount);
+					}
+				}
+			);
 
-        });
-    });
+		});
+	});
 
 });


### PR DESCRIPTION
This PR includes
* a new API to dynamically update scroller content (adapter)
* isLoading, topVisible, topVisibleElement, topVisibleScope are presented within adapter
* deep chain access to these props (and to adapter) on $scope
* memory leaks (https://github.com/Hill30/NGScroller/issues/63) fix
* items requesting never ends (https://github.com/Hill30/NGScroller/issues/64) fix
* some minor refactoring (like a 'scrolling' flag removing)