### PR TITLE
ui.scroll v1.1.1

### DIFF
--- a/modules/scroll/README.md
+++ b/modules/scroll/README.md
@@ -188,6 +188,9 @@ Do not ask me why this woodoo is necessary, but as of Chrome version 30 it is ju
 
 ###History
 
+####v1.1.1
+* Fixed jqlite on $destroy error.
+
 ####v1.1.0
 * Introduced API to dynamically update scroller content.
 * Deep 'name' properties access via dot-notation in template.

--- a/modules/scroll/scroll.js
+++ b/modules/scroll/scroll.js
@@ -144,7 +144,9 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
             };
             topPadding = createPadding(padding(repeaterType), element, 'top');
             bottomPadding = createPadding(padding(repeaterType), element, 'bottom');
-            $scope.$on('$destroy', template.remove);
+            $scope.$on('$destroy', function() {
+              template.remove();
+            });
             return builder = {
               viewport: viewport,
               topPadding: topPadding.paddingHeight,


### PR DESCRIPTION
This PR contains the fix for jqlite on $destroy error.
(The discussion of the problem is here: https://github.com/Hill30/NGScroller/issues/64#issuecomment-77744442)