### PR TITLE
Add support for meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist/
 # don't track generated/copied html demo files
 demo/*.html
 .DS_Store
+.versions

--- a/gruntFile.js
+++ b/gruntFile.js
@@ -14,6 +14,10 @@ module.exports = function (grunt) {
   grunt.registerTask('dist:sub', ['ngmin', 'uglify:sub']);
   grunt.registerTask('dist:demo', ['concat:html_doc', 'copy']);
 
+  // Meteor build tasks
+  grunt.registerTask('meteor-publish', ['dist', 'exec:meteor-init', 'exec:meteor-publish']);
+  grunt.registerTask('meteor', ['exec:meteor-init', 'exec:meteor-publish']);
+
 
   // HACK TO ACCESS TO THE COMPONENT-PUBLISHER
   function fakeTargetTask(prefix) {
@@ -140,7 +144,18 @@ module.exports = function (grunt) {
       }
     },
     clean: {
-      rm_tmp: {src: ['tmp']}
+      rm_tmp: {src: ['tmp']},
+      meteor: ['.build.*', 'versions.json']
+    },
+    exec: {
+      'meteor-init': {
+        command: [
+          'type meteor >/dev/null 2>&1 || { curl https://install.meteor.com/ | sh; }'
+        ].join(';')
+      },
+      'meteor-publish': {
+        command: 'meteor publish'
+      }
     },
     jshint: {
       src: {

--- a/package.js
+++ b/package.js
@@ -1,0 +1,15 @@
+Package.describe({
+  name: 'angularui:ui-utils',
+  version: '0.2.3',
+  summary: 'Angular-ui-utils package for meteor.',
+  git: 'https://github.com/angular-ui/ui-utils.git',
+  documentation: 'README.md'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@0.9.0.1');
+
+  api.use('urigo:angular@0.8.4', 'client');
+
+  api.addFiles('dist/main/ui-utils.js', 'client');
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "grunt-conventional-changelog": "~1.0.0",
     "grunt-karma": "~0.6.2",
     "load-grunt-tasks": "~0.2.0",
-    "grunt-ngmin": "0.0.3"
+    "grunt-ngmin": "0.0.3",
+    "grunt-exec": "^0.4.6",
+    "spacejam": "^1.1.1"
   },
   "scripts": {},
   "main": "./modules/utils.js",


### PR DESCRIPTION
Hi angular-ui team,

I'm a package maintainer for Meteor.js, a popular full-stack JavaScript framework.
I'm also a developer on angular-meteor, a library that let's you work with AngularJS on top of Meteor.

A lot of our users use ui-utils and it right now there is a separate package and Github repo that simply manually copies your distribution and publish it to Meteor.
This PR will allow you to directly publish updated versions of ui-utils as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer to the angularui organization there.

I've already published the current version of the package on Atmosphere (Meteor's package directory). When you release new versions of ui-utils, you'll be able to publish them to Atmosphere by running make meteor.

Thanks & best regards,
Dotan
