### PR TITLE
Ensure initial scrollfix state is set

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -52,6 +52,7 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
       }
 
       $target.on('scroll', onScroll);
+      onScroll();
 
       // Unbind scroll event handler when directive is removed
       scope.$on('$destroy', function() {


### PR DESCRIPTION
Without this, any element with `ui-scrollfix` applied initially has the `.ui-scrollfix` class applied until I scroll the page. After that, the element behaves as expected.