### PR TITLE
Update $pending object on async validations

### DIFF
--- a/modules/validate/validate.js
+++ b/modules/validate/validate.js
@@ -35,6 +35,11 @@ angular.module('ui.validate',[]).directive('uiValidate', function () {
           var expression = scope.$eval(exprssn, { '$value' : valueToValidate });
           if (angular.isObject(expression) && angular.isFunction(expression.then)) {
             // expression is a promise
+            if (angular.isUndefined(ctrl.$pending)) {
+              ctrl.$pending = {};
+            }
+            // set pending state until promise is resolved
+            ctrl.$pending[key] = true;
             expression.then(function(){
               ctrl.$setValidity(key, true);
             }, function(){


### PR DESCRIPTION
When a custom validator returns a promise, uiValidation directive adds the validation key to ModelController's $pending object.
When promise is resolve or rejected. $pending[key] is deleted automatically.

This allow to use $pending variable from the view to show transient messages while validation is taking place.