### PR TITLE
Added MIT license to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,6 +5,7 @@
   "version": "0.2.3",
   "homepage": "http://angular-ui.github.com",
   "main": "./modules/utils.js",
+  "license": "MIT",
   "dependencies": {
     "angular": ">= 1.0.2"
   },


### PR DESCRIPTION
This is useful for automatically generating a list of used 3rd party software and their licenses. E.g. using grunt-license-bower task.