### PR TITLE
Ui uploader data

### DIFF
--- a/modules/uploader/uploader.js
+++ b/modules/uploader/uploader.js
@@ -37,7 +37,7 @@ function uiUploader($log) {
             }
             if (self.files[i].active)
                 continue;
-            ajaxUpload(self.files[i], self.options.url);
+            ajaxUpload(self.files[i], self.options.url, self.options.data);
         }
     }
     

--- a/modules/uploader/uploader.js
+++ b/modules/uploader/uploader.js
@@ -64,9 +64,10 @@ function uiUploader($log) {
         return (bytes / Math.pow(1024, i)).toFixed(i ? 1 : 0) + ' ' + sizes[isNaN(bytes) ? 0 : i + 1];
     }
 
-    function ajaxUpload(file, url) {
-        var xhr, formData, prop, data = '',
-            key = '' || 'file';
+    function ajaxUpload(file, url, data) {
+        var xhr, formData, prop, key = '' || 'file';
+        data = data || {};
+        
         self.activeUploads += 1;
         file.active = true;
         xhr = new window.XMLHttpRequest();


### PR DESCRIPTION
ui-uploader not supported additional parameters to the upload POST request.

Variable named "data" is declared in the beginning og "ajaxUpload" function.
```javascript
function ajaxUpload(file, url) {
        var xhr, formData, prop, data = '',
            key = '' || 'file';
```
Later on in this function, there is a code that check if data not empty, to add all its properties to the formData object as request parameters (POST variables...)
```javascript
        // Append additional data if provided:
        if (data) {
            for (prop in data) {
                if (data.hasOwnProperty(prop)) {
                    formData.append(prop, data[prop]);
                }
            }
        }
```
But there is no way to populate this variable with data (the if statement in the previous example will never evaluate as "true").

As a result, the only way to add parameters to the upload request is using the query string (changing the URL) instead of using request body.

The solution (without breaking backword compitability) is to add 3rd argument "data" to "ajaxUpload". This argument is populated from "options.data".
