### PR TITLE
Reference offset from client top

### DIFF
--- a/modules/scrollfix/scrollfix.js
+++ b/modules/scrollfix/scrollfix.js
@@ -35,11 +35,13 @@ angular.module('ui.scrollfix',[]).directive('uiScrollfix', ['$window', function 
         }
       }
 
-      fixLimit = absolute ? attrs.uiScrollfix : elm[0].offsetTop + shift;
+      //fixLimit = absolute ? attrs.uiScrollfix : elm[0].offsetTop + shift;
+      fixLimit = absolute ? attrs.uiScrollfix : $(elm).offset().top + shift;
 
       function onScroll() {
 
-        var limit = absolute ? attrs.uiScrollfix : elm[0].offsetTop + shift;
+        //var limit = absolute ? attrs.uiScrollfix : elm[0].offsetTop + shift;
+        var limit = absolute ? attrs.uiScrollfix : $(elm).offset().top + shift;
 
         // if pageYOffset is defined use it, otherwise use other crap for IE
         var offset = uiScrollfixTarget ? $target[0].scrollTop : getWindowScrollTop();


### PR DESCRIPTION
Instead of referencing from parent element (offsetTop), to reference from window top instead (offset().top)
