### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,6 @@
   "author": "AngularUI Team",
   "name": "angular-ui-utils",
   "description": "AngularUI Utilities - Companion Suite for AngularJS",
-  "version": "0.2.3",
   "homepage": "http://angular-ui.github.com",
   "main": "./modules/utils.js",
   "license": "MIT",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property
