### PR TITLE
Expose reload function to adapter to be able to reload manually

### DIFF
--- a/modules/scroll/scroll.js
+++ b/modules/scroll/scroll.js
@@ -513,6 +513,7 @@ angular.module('ui.scroll', []).directive('uiScrollViewport', [
 					});
 					adapter = {};
 					adapter.isLoading = false;
+					adapter.reload = reload;
 					applyUpdate = function(wrapper, newItems) {
 						var i, inserted, item, j, k, l, len, len1, len2, ndx, newItem, oldItemNdx;
 						inserted = [];


### PR DESCRIPTION
In my case I am switching the actual data source for `datasource` in the background and $watching the revision didn't work. Also, $watching is usually more expensive and actually not needed (why would I have to compare variables if I just want to call reload?), thus having the ability to manually call a reload via the adapter is quite helpful.
Actually I would remove the revision $watcher but maybe that can be done in another release.
